### PR TITLE
Run the offline test suite in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,46 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        # The README supports Python 3.10 or newer.
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+
+      - name: Byte-compile the application and tests
+        run: python -m compileall -q summarizer tests
+
+      - name: Run the offline suite
+        run: python -m pytest -q
+
+      - name: Run the offline suite through importlib import mode
+        run: python -m pytest -q --import-mode=importlib


### PR DESCRIPTION
Adds a GitHub Actions workflow running the offline suite. There was no `.github/` directory at all, so nothing currently verifies a push or a pull request.

## What it runs

On pushes to `main` and on every pull request, across Python 3.10–3.13 (the range the README supports), with `fail-fast: false` so every version reports:

1. `python -m pip install -r requirements-dev.txt`
2. `python -m compileall -q summarizer tests`
3. `python -m pytest -q`
4. `python -m pytest -q --import-mode=importlib`

Steps 3 and 4 are the two invocations the README already documents. Byte-compiling first turns a syntax error into a clear failure ahead of collection.

The suite needs no secrets and no services: an autouse fixture blocks outbound sockets, and provider access is faked, so no OpenAI credential, Ollama service, or model download is involved. `permissions` is `contents: read`, dependencies are pip-cached on `requirements-dev.txt`, and superseded runs are cancelled by a concurrency group.

## Verification

I simulated the full matrix locally before writing the workflow — all four interpreters, both import modes, plus `compileall` — and every combination passed, so this should be green on arrival rather than red.

Not verified: `actionlint` isn't installed here, so the workflow was validated by parsing it and checking the step graph rather than by a real linter.