### PR TITLE
Implement automatic strategy selection and direct summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project is being rebuilt as a generalized, source-grounded hierarchical summarization pipeline for extremely long artifacts. The current application provides a provider-neutral foundation while preserving the legacy flat, sentence-chunked workflow.
 
-Canonical ingestion, token-aware segmentation, and structured leaf summarization are now available as library components in `summarizer.ingestion`, `summarizer.tokenization`, `summarizer.segmentation`, `summarizer.summaries`, and `summarizer.leaf`. The command-line workflow still runs the legacy flat, sentence-chunked path and does not consume them yet.
+Canonical ingestion, token-aware segmentation, structured leaf summarization, token-budget arithmetic, and whole-document direct summarization are now available as library components in `summarizer.ingestion`, `summarizer.tokenization`, `summarizer.segmentation`, `summarizer.summaries`, `summarizer.leaf`, `summarizer.budget`, and `summarizer.direct`. The command-line workflow still runs the legacy flat, sentence-chunked path and does not consume them yet.
 
 Hierarchical merging, source grounding across merge levels, concurrency, and quality evaluation are not implemented yet.
 
@@ -126,6 +126,26 @@ When a provider can constrain decoding, the request carries a JSON Schema — a 
 Source text is placed only in the request's input slot, never in its instructions, and the instructions state that fenced content is data rather than instructions. The stage fails on the first segment whose response cannot be validated, naming the segment and the failing field without echoing the payload or the source.
 
 The command line does not consume leaf records yet.
+
+## Strategy selection and token budgets
+
+`summarizer.budget` decides how a document should be executed before any provider is called:
+
+```
+usable input = context window − prompt and schema overhead − reserved output − safety margin
+```
+
+Every term is measured or configured, not guessed. Overhead is measured by building a real request and counting it, because a hard-coded figure would rot the moment the prompt or the record changed — it is 794 tokens for `gpt-4o-mini`, of which the schema alone is 521, and it rises to 918 when overlap is configured. The safety margin is the larger of a fixed floor and a fraction of the window, so a small window keeps a usable floor while a very large one is not charged thousands of tokens for nothing.
+
+A configuration that leaves no usable capacity raises an error naming every term, rather than returning a meaningless number. That case is reachable rather than theoretical: the conservative estimator charges roughly four times a real tokenizer on this project's own prompt text, which exhausts a small window on its own.
+
+`--strategy auto` selects direct only when the document provably fits, the context window is *known* rather than assumed, and any configured direct cap is respected; otherwise it selects hierarchical. `--strategy direct` fails before a provider call when the document does not fit, reporting the same arithmetic the decision used. `--strategy hierarchical` always splits.
+
+Context windows come from a hand-maintained table, because there is no offline source of truth and, for OpenAI, no online one either — the client exposes no window, and `tiktoken` maps model names to encodings rather than to sizes. An unrecognized model therefore resolves to an assumed window that is reported as assumed, and `auto` routes it to hierarchical rather than gambling a direct request on a guess. Pass `--context-window` to state a window explicitly and recover the direct path.
+
+Two provider behaviours are worth knowing, because they differ in a way that matters. OpenAI rejects an oversized request outright. Ollama silently truncates the prompt and returns a plausible answer, so on the local path the budget arithmetic is the only thing standing between a too-large document and a confidently ungrounded summary.
+
+The reserved output size is accounted for when sizing a request but not yet enforced on the provider, and the command line accepts strategy configuration without yet running the new pipeline — it still executes the legacy workflow.
 
 Historical scripts under `omscs-ml-lectures/` remain available but are not part of the modern application entry point.
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The command line does not consume leaf records yet.
 usable input = context window − prompt and schema overhead − reserved output − safety margin
 ```
 
-Every term is measured or configured, not guessed. Overhead is measured by building a real request and counting it, because a hard-coded figure would rot the moment the prompt or the record changed — it is 794 tokens for `gpt-4o-mini`, of which the schema alone is 521, and it rises to 918 when overlap is configured. The safety margin is the larger of a fixed floor and a fraction of the window, so a small window keeps a usable floor while a very large one is not charged thousands of tokens for nothing.
+Every term is measured or configured, not guessed. Overhead is measured by building a real request and counting it, because a hard-coded figure would rot the moment the prompt or the record changed — it is 798 tokens for `gpt-4o-mini`, of which the schema alone is 521, and it rises to 918 when overlap is configured. The safety margin is the larger of a fixed floor and a fraction of the window, so a small window keeps a usable floor while a very large one is not charged thousands of tokens for nothing.
 
 A configuration that leaves no usable capacity raises an error naming every term, rather than returning a meaningless number. That case is reachable rather than theoretical: the conservative estimator charges roughly four times a real tokenizer on this project's own prompt text, which exhausts a small window on its own.
 

--- a/docs/plans/2026-09-03-strategy-selection-design.md
+++ b/docs/plans/2026-09-03-strategy-selection-design.md
@@ -136,6 +136,19 @@ This issue delivers the budget calculator, the context table, strategy selection
 7. **Budget settings live in `StrategyConfig`**, not `AppConfig`, to avoid the positional-construction hazard.
 8. **The output reserve is accounted for but not enforced.** Enforcing it means adding an output cap to `GenerationRequest` and mapping it in both adapters, which re-opens the provider contract for a criterion that only requires the reservation be *accounted* for.
 
+## Measured on completion
+
+The implementation's own numbers, for comparison against the estimates above:
+
+| counter | overlap | instructions | schema | fencing | total |
+|---|---|---|---|---|---|
+| `tiktoken:o200k_base` | no | 249 | 521 | 24 | **794** |
+| `tiktoken:o200k_base` | yes | 343 | 521 | 54 | **918** |
+| `estimate:utf8-bytes` | no | 1,216 | 2,196 | 64 | **3,476** |
+| `estimate:utf8-bytes` | yes | 1,631 | 2,196 | 138 | **3,965** |
+
+Usable input capacity for `gpt-4o-mini` on defaults is **123,622 tokens**. The estimator's 3,476-token overhead exceeds a 2,048-token window on its own, which is what makes the underflow error load-bearing rather than defensive.
+
 ## Open decisions
 
 These change the shape of the code or reflect a product judgment this issue should not make alone:

--- a/docs/plans/2026-09-03-strategy-selection-design.md
+++ b/docs/plans/2026-09-03-strategy-selection-design.md
@@ -16,13 +16,13 @@ The boundaries against neighbouring issues are narrow and worth stating, because
 
 The design is driven by measurements against the pinned dependencies rather than estimates, because two of them are counter-intuitive.
 
-**The schema dominates the fixed overhead.** `leaf_summary_schema()` is sent on every request. Serialized compactly and counted with `o200k_base` it is **521 tokens**, against **253** for the instructions and **27** for the fencing — so the schema is 65% of an 801-token fixed cost. Of those 521, **113 are pydantic docstrings** rendered into JSON Schema `description` keys and 84 are auto-generated `title` keys, so 38% of the dominant term is documentation shipped to the model on every call.
+**The schema dominates the fixed overhead.** `leaf_summary_schema()` is sent on every request. Serialized compactly and counted with `o200k_base` it is **521 tokens**, against **251** for the instructions and **26** for the fencing — so the schema is 65% of a 798-token fixed cost. The compact serialization is itself optimistic: the OpenAI SDK's default `json.dumps` of the same object is 648 tokens, so the real wire cost is roughly 127 tokens higher than measured, which the safety margin absorbs. Of those 521, **113 are pydantic docstrings** rendered into JSON Schema `description` keys and 84 are auto-generated `title` keys, so 38% of the dominant term is documentation shipped to the model on every call.
 
-**Overhead is not one constant.** When a segment carries overlap, the prompt gains a second instruction block and two more fences: overhead rises to roughly **930 tokens**. A calculator that assumes 801 under-reserves by ~130 tokens whenever overlap is configured.
+**Overhead is not one constant.** When a segment carries overlap, the prompt gains a second instruction block and two more fences: overhead rises to **918 tokens**. A calculator that assumes 798 under-reserves by 120 tokens per request whenever overlap is configured — which is a trap for issue #7, since `select_strategy` deliberately measures the no-overlap figure that a direct request actually incurs.
 
 **The conservative counter makes small windows unusable.** `ConservativeUtf8TokenCounter` — what `resolve_token_counter` returns for every Ollama tag — costs **4.2×** on the schema and **4.8×** on the instructions relative to a real tokenizer, because it charges one token per UTF-8 byte. At a 4,096-token window with a 1,024-token output reserve, usable input capacity computes to **−674**. Non-positive capacity is reachable on default local configuration and must therefore be a named error, not an arithmetic underflow.
 
-**Direct is the common case, not the exotic one.** At a 128,000-token window the usable input capacity is 119,775 tokens, which is roughly 514 KB of prose. The entire 30-file corpus in this repository is 84,948 tokens and fits in a single request; `input.txt` is 307 tokens. On the project's own defaults, a window-only `auto` selects `direct` for every input this repository has ever handled, and the hierarchy #7 builds would be unreachable without configuration. That is a product consequence, not a bug, and it is addressed under strategy selection below.
+**Direct is the common case, not the exotic one.** At a 128,000-token window the usable input capacity is 123,618 tokens, which is roughly 514 KB of prose. The entire 30-file corpus in this repository is 84,948 tokens and fits in a single request; `input.txt` is 307 tokens. On the project's own defaults, a window-only `auto` selects `direct` for every input this repository has ever handled, and the hierarchy #7 builds would be unreachable without configuration. That is a product consequence, not a bug, and it is addressed under strategy selection below.
 
 **The two providers fail differently, and one of them does not fail at all.** OpenAI's Responses API defaults `truncation` to `disabled`, so oversized input is a 400 that the adapter already maps to `ProviderRequestError`. Ollama silently truncates: a ~1,700-token prompt sent with `num_ctx=512` returned `prompt_eval_count=258` and `done_reason="length"` with **no error and plausible-looking output**. On the local path, budget arithmetic is the only defence against a confidently ungrounded summary, because the response status does not reveal the loss.
 
@@ -49,7 +49,8 @@ This is the selected approach. It reuses the request construction, the tolerant 
 It requires two small, honest additions rather than workarounds:
 
 - **`BoundaryKind.DOCUMENT`.** The existing kinds all describe a boundary *within* a document. A unit that is the entire document has no such boundary, and forcing `HARD` or `PARAGRAPH` would misreport provenance. Naming the case is cheaper than lying about it.
-- **A prompt that does not claim to be a fragment.** The leaf instructions open "You extract structured information from one region of a longer document." For a direct run there is no longer document, and telling a model it is reading a fragment invites it to hedge about missing context — the opposite of the cohesive result the acceptance criteria ask for. The framing sentence is therefore selected by whether the unit is the whole document, and `LEAF_PROMPT_VERSION` is bumped because output can change for identical input.
+- **A distinct identifier, `D000001`.** Segmentation numbers its segments `S000001` upward, so reusing that would give a direct run and a hierarchical run the same identifier for different extents. Provenance is a bare tuple of identifiers carrying no boundary kind, so the two meanings would be unrecoverable exactly where issues #8 and #9 need to trace a root back to source.
+- **A prompt that does not claim to be a fragment.** The leaf instructions describe their input as "one region of a longer document", and five further rules call it "the region". For a direct run there is no longer document, and telling a model it holds a fragment invites it to hedge about missing context — the opposite of the cohesive result the acceptance criteria ask for. The noun is therefore substituted throughout the instructions rather than in the opening sentence alone; changing only the opening would leave the rules contradicting it, which an earlier revision of this branch did. `LEAF_PROMPT_VERSION` is bumped because output can change for identical input.
 
 ## Budget arithmetic
 
@@ -131,23 +132,23 @@ This issue delivers the budget calculator, the context table, strategy selection
 2. **`LEAF_PROMPT_VERSION` is bumped** because the framing sentence now varies. Nothing caches on it yet, so this is free today and would not be later.
 3. **Overhead is measured at runtime** and pinned by a test, rather than hard-coded.
 4. **The safety margin is `max(fixed, fraction × window)`**, defaulting to 256 tokens and 2%.
-5. **An unknown model routes `auto` to hierarchical** instead of failing or guessing that a default window is knowledge.
+5. **An unknown model routes `auto` to hierarchical** instead of failing or guessing that a default window is knowledge, and explicit `direct` against an unknown window is refused outright rather than checked against the guess. That combination is the dangerous one: the local provider truncates silently, so a fit established against an assumed window yields a confidently ungrounded summary.
 6. **The direct cap defaults to unset**, so behaviour matches the acceptance criterion while leaving the quality question configurable.
 7. **Budget settings live in `StrategyConfig`**, not `AppConfig`, to avoid the positional-construction hazard.
 8. **The output reserve is accounted for but not enforced.** Enforcing it means adding an output cap to `GenerationRequest` and mapping it in both adapters, which re-opens the provider contract for a criterion that only requires the reservation be *accounted* for.
 
 ## Measured on completion
 
-The implementation's own numbers, for comparison against the estimates above:
+The implementation's own numbers, for comparison against the estimates above. Note that `measure_overhead` reads `LEAF_PROMPT_VERSION` through the fence digest, so bumping that string moves the budget by a few tokens — an earlier draft of this table was measured against `leaf-prompt/1` and reported 794 and 123,622.
 
 | counter | overlap | instructions | schema | fencing | total |
 |---|---|---|---|---|---|
-| `tiktoken:o200k_base` | no | 249 | 521 | 24 | **794** |
+| `tiktoken:o200k_base` | no | 251 | 521 | 26 | **798** |
 | `tiktoken:o200k_base` | yes | 343 | 521 | 54 | **918** |
 | `estimate:utf8-bytes` | no | 1,216 | 2,196 | 64 | **3,476** |
 | `estimate:utf8-bytes` | yes | 1,631 | 2,196 | 138 | **3,965** |
 
-Usable input capacity for `gpt-4o-mini` on defaults is **123,622 tokens**. The estimator's 3,476-token overhead exceeds a 2,048-token window on its own, which is what makes the underflow error load-bearing rather than defensive.
+Usable input capacity for `gpt-4o-mini` on defaults is **123,618 tokens**. The estimator's 3,476-token overhead exceeds a 2,048-token window on its own, which is what makes the underflow error load-bearing rather than defensive.
 
 ## Open decisions
 

--- a/docs/plans/2026-09-03-strategy-selection-design.md
+++ b/docs/plans/2026-09-03-strategy-selection-design.md
@@ -1,0 +1,148 @@
+# Automatic Strategy Selection and Direct Summarization Design
+
+## Scope
+
+Issue #6 adds safe context-budget arithmetic and completes the `direct` and `auto` execution paths. A document that genuinely fits is summarized in one call; one that does not is routed toward hierarchical execution instead of being sent as an invalid request.
+
+The boundaries against neighbouring issues are narrow and worth stating, because three of them are easy to drift into:
+
+- **Issue #4 owns segmentation** and **issue #5 owns leaf records.** Both are merged. This issue consumes `SourceDocument`, `SourceSegment`, `TokenCounter`, `build_leaf_request`, `parse_leaf_summary`, and `SummaryNode` as they stand, and changes them only where noted below.
+- **Issue #7 owns the hierarchy.** Tree construction, branching factor, merge prompts, and forward-progress guarantees are its work. This issue ships the budget calculator #7 will consume and *routes* to hierarchical without implementing it.
+- **Issue #9 owns the audit artifact.** The run metadata here is an in-process value returned to callers, not a serialized file.
+- **Issue #11 hashes behaviour-relevant configuration into cache keys**, so every configuration value added here becomes a future cache-key input.
+- **Issue #12 owns the end-to-end demonstration** and the README rewrite. This issue therefore adds strategy configuration to the CLI, but does not rewire `main()` onto the new pipeline — the command line keeps running the legacy path, exactly as #4 and #5 left it.
+
+## What the numbers say
+
+The design is driven by measurements against the pinned dependencies rather than estimates, because two of them are counter-intuitive.
+
+**The schema dominates the fixed overhead.** `leaf_summary_schema()` is sent on every request. Serialized compactly and counted with `o200k_base` it is **521 tokens**, against **253** for the instructions and **27** for the fencing — so the schema is 65% of an 801-token fixed cost. Of those 521, **113 are pydantic docstrings** rendered into JSON Schema `description` keys and 84 are auto-generated `title` keys, so 38% of the dominant term is documentation shipped to the model on every call.
+
+**Overhead is not one constant.** When a segment carries overlap, the prompt gains a second instruction block and two more fences: overhead rises to roughly **930 tokens**. A calculator that assumes 801 under-reserves by ~130 tokens whenever overlap is configured.
+
+**The conservative counter makes small windows unusable.** `ConservativeUtf8TokenCounter` — what `resolve_token_counter` returns for every Ollama tag — costs **4.2×** on the schema and **4.8×** on the instructions relative to a real tokenizer, because it charges one token per UTF-8 byte. At a 4,096-token window with a 1,024-token output reserve, usable input capacity computes to **−674**. Non-positive capacity is reachable on default local configuration and must therefore be a named error, not an arithmetic underflow.
+
+**Direct is the common case, not the exotic one.** At a 128,000-token window the usable input capacity is 119,775 tokens, which is roughly 514 KB of prose. The entire 30-file corpus in this repository is 84,948 tokens and fits in a single request; `input.txt` is 307 tokens. On the project's own defaults, a window-only `auto` selects `direct` for every input this repository has ever handled, and the hierarchy #7 builds would be unreachable without configuration. That is a product consequence, not a bug, and it is addressed under strategy selection below.
+
+**The two providers fail differently, and one of them does not fail at all.** OpenAI's Responses API defaults `truncation` to `disabled`, so oversized input is a 400 that the adapter already maps to `ProviderRequestError`. Ollama silently truncates: a ~1,700-token prompt sent with `num_ctx=512` returned `prompt_eval_count=258` and `done_reason="length"` with **no error and plausible-looking output**. On the local path, budget arithmetic is the only defence against a confidently ungrounded summary, because the response status does not reveal the loss.
+
+## Considered approaches
+
+The central question is how `direct` produces a result, given that #5's machinery is built around a segment.
+
+### A dedicated direct record and prompt
+
+Introduce a `DirectSummary` record with its own schema, prompt, and version constants. Maximum control, and it leaves #5 untouched. Rejected: it gives issue #9 two unrelated shapes to synthesize from, duplicates the schema and prompt versioning, and abandons the leaf design's explicit choice to keep one central record for the whole hierarchy.
+
+### Reuse segmentation with a budget large enough to yield one segment
+
+Attractive, and it was the first approach attempted: if the whole document fits, `segment_document` should pack it into a single segment and the leaf pipeline could be reused unchanged.
+
+**This does not work, and the reason is worth recording.** Headings force a hard break in packing, so a document with more than one heading never collapses to a single segment regardless of budget. Measured: a 26-token document with three headings yields three segments even at a budget of 52. Only heading-free documents collapse. Verified rather than assumed, after the design initially depended on it.
+
+### A document-spanning segment, constructed directly
+
+Build one `SourceSegment` covering the whole canonical document and pass it through the existing request builder, parser, and validator.
+
+This is the selected approach. It reuses the request construction, the tolerant parser, the strict validator, and the provenance rules that were hardened in #18, and it produces the same `SummaryNode` the rest of the hierarchy consumes. Because the record's core range spans the document, quotations are checked against the whole text and the single legal identifier is the document's own — so `_validate_provenance` needs no change.
+
+It requires two small, honest additions rather than workarounds:
+
+- **`BoundaryKind.DOCUMENT`.** The existing kinds all describe a boundary *within* a document. A unit that is the entire document has no such boundary, and forcing `HARD` or `PARAGRAPH` would misreport provenance. Naming the case is cheaper than lying about it.
+- **A prompt that does not claim to be a fragment.** The leaf instructions open "You extract structured information from one region of a longer document." For a direct run there is no longer document, and telling a model it is reading a fragment invites it to hedge about missing context — the opposite of the cohesive result the acceptance criteria ask for. The framing sentence is therefore selected by whether the unit is the whole document, and `LEAF_PROMPT_VERSION` is bumped because output can change for identical input.
+
+## Budget arithmetic
+
+```
+usable_input = window − overhead − output_reserve − safety_margin
+```
+
+Every term is either measured or configured; none is guessed.
+
+**`overhead` is measured, not hard-coded.** An acceptance criterion covers "overhead changes", so a constant would be wrong by construction the moment the prompt or the record changes. It is computed as the token count of the filled instruction template, plus the compactly-serialized schema, plus the fencing — with the overlap-carrying variant taken whenever overlap is configured, since that is the larger of the two. A test pins the measurement so that editing either string fails loudly rather than silently shrinking the budget.
+
+The schema is counted in its compact serialization. That is an approximation of what the provider's own tokenizer sees, and the direction of the error is stated: compact is the closer proxy to the wire, while an indented form would overstate by 67%. Approximating in the direction of a smaller reservation is the wrong direction for safety, which is one reason the safety margin exists.
+
+**`safety_margin` is `max(fixed, fraction × window)`.** A fixed margin alone is negligible at 262,144 tokens; a fractional margin alone discards 13,000 tokens there for no reason while under-protecting a 4,096-token window. Taking the maximum gives a floor for small windows and proportionality for large ones. Defaults are 256 tokens and 2%.
+
+**Non-positive capacity is an error with the arithmetic in it.** `BudgetError` reports the window, each subtracted term, and the result, because the operator's next action depends on which term dominated — a bigger model, a smaller output reserve, or an explicit window override.
+
+## Context windows
+
+There is no offline source of truth for a model's context window, and for OpenAI there is no *online* one either. The installed `openai` 3.7.0 exposes no window anywhere; `Model` carries only `{id, created, object, owned_by, shutdown_date}`. `tiktoken` maps names to encodings, never to sizes. Ollama does expose an architectural length through `show()`, but the key is architecture-prefixed rather than tag-named — tag `qwen3.8` reports `qwen35.context_length` — and it is a network call that is unavailable before a pull and unusable in the offline suite.
+
+So the window comes from a hand-maintained table with a two-tier lookup, exact name then prefix, mirroring the shape `tiktoken` already uses and which is what makes `gpt-4o-mini` resolve at all.
+
+**An unknown model does not fail, and does not silently get a default that pretends to be knowledge.** It resolves to a conservative assumed window, and the resolution records that it was assumed. `auto` then routes an unknown model to hierarchical rather than gambling a direct request on a guess — the only option that keeps arbitrary local tags working, as the epic requires, while never sending a request that cannot fit. An operator who knows better states the window explicitly and gets the direct path back.
+
+This mirrors `TokenCounter.exact`, which already exists so that an estimate can be visibly an estimate.
+
+## Strategy selection
+
+`direct` is chosen only when the measured document token count fits the usable input capacity. The measurement is `counter.count(document.text)`, which is exactly the text a direct request sends — not the sum of segment counts, which differs under BPE and diverges further under overlap.
+
+`auto` resolves to `direct` when the document fits **and** the window was known rather than assumed **and** no configured direct cap is exceeded; otherwise `hierarchical`.
+
+The optional cap exists because of the measurement above: without one, window-only selection sends 85,000-token documents in a single call and #7's hierarchy is unreachable on defaults. Whether a single enormous call produces a *better* summary than a hierarchy is a quality question this issue is not entitled to answer, so the cap defaults to unset — window-only behaviour, exactly as the acceptance criterion words it — and exists so the question can be answered later by configuration rather than by a code change.
+
+Explicit `direct` that does not fit fails before any provider call, with the same numbers the decision used.
+
+## Domain model
+
+Two frozen dataclasses, not pydantic models: these are computed locally from configuration and measurement, and the leaf design reserved pydantic for records built from untrusted model output.
+
+- **`StrategyConfig`** carries the strategy name, an optional explicit context window, the output reserve, the two safety-margin terms, and the optional direct cap. It validates its own fields, so a bad value becomes an argument-parser error rather than a traceback.
+- **`BudgetReport`** records what the decision saw: the resolved window and whether it was assumed, the counter's identity and whether it is exact, each measured overhead term, the reserve, the margin, the computed capacity, the document's token count, the selected strategy, and a machine-readable reason. It is what satisfies the run-metadata criterion and what makes a rejection explicable.
+
+`StrategyConfig` becomes a fourth field on `ParsedConfig` rather than more fields on `AppConfig`. `AppConfig` is constructed positionally in existing tests, and a commit already exists in this repository's history solely to repair that after a field moved; keeping budget settings in their own record avoids re-opening that hazard and mirrors how `RetryPolicy` and `LegacyWorkflowConfig` are already separate.
+
+## Errors and invariants
+
+- A configuration whose computed capacity is non-positive raises `BudgetError` naming every term.
+- Explicit `direct` with a document that does not fit raises `BudgetError` before a provider call.
+- An unknown model resolves to an assumed window and is reported as assumed; it never silently claims exactness.
+- Strategy validation happens during argument parsing, so the command line reports it as a usage error. This matters because `main()` currently catches only `OSError` and `ProviderError`, so a `ValueError` escaping into it would print a traceback.
+- The direct path calls the provider exactly once and never converts a provider failure into summary text.
+
+## Determinism
+
+The same document, model, counter, and configuration produce an identical `BudgetReport` and an identical `GenerationRequest`. The report is therefore safe to hash for #11's cache keys, and a strategy decision is reproducible from its inputs alone.
+
+## Module layout
+
+- `summarizer/budget.py` — the context table, overhead measurement, capacity arithmetic, `BudgetError`, `BudgetReport`, and strategy selection.
+- `summarizer/direct.py` — the document-spanning segment and the direct summarization stage.
+- `summarizer/config.py` — `StrategyConfig`.
+- `summarizer/cli.py` — the new flags.
+
+## Testing
+
+All offline, following the established discipline: sockets blocked by the autouse fixture, providers faked at the `client_factory` seam or by a hand-written `generate`, and deterministic injected counters wherever a boundary matters. A real `tiktoken` encoding is constructed in exactly one place, guarded so that only vocabulary availability can skip it.
+
+Coverage follows the acceptance criteria, with the boundary cases named explicitly: a document one token under capacity and one token over it; an overhead change shifting the decision; each safety-margin term dominating; a direct success; a forced-direct rejection carrying its arithmetic; automatic hierarchical selection; an unknown model routing to hierarchical; and a configuration whose capacity underflows.
+
+## Delivery boundary
+
+This issue delivers the budget calculator, the context table, strategy selection, the direct path, `StrategyConfig`, the CLI flags, and their tests. The legacy command-line workflow, the merge stage, and the audit artifact are untouched.
+
+## Decisions taken
+
+1. **Direct reuses the leaf machinery through a document-spanning segment**, rather than a parallel record. It costs one new `BoundaryKind` member and one prompt branch, and it keeps a single central record for the hierarchy.
+2. **`LEAF_PROMPT_VERSION` is bumped** because the framing sentence now varies. Nothing caches on it yet, so this is free today and would not be later.
+3. **Overhead is measured at runtime** and pinned by a test, rather than hard-coded.
+4. **The safety margin is `max(fixed, fraction × window)`**, defaulting to 256 tokens and 2%.
+5. **An unknown model routes `auto` to hierarchical** instead of failing or guessing that a default window is knowledge.
+6. **The direct cap defaults to unset**, so behaviour matches the acceptance criterion while leaving the quality question configurable.
+7. **Budget settings live in `StrategyConfig`**, not `AppConfig`, to avoid the positional-construction hazard.
+8. **The output reserve is accounted for but not enforced.** Enforcing it means adding an output cap to `GenerationRequest` and mapping it in both adapters, which re-opens the provider contract for a criterion that only requires the reservation be *accounted* for.
+
+## Open decisions
+
+These change the shape of the code or reflect a product judgment this issue should not make alone:
+
+1. **Whether to trim `description` and `title` from the leaf schema**, reclaiming 197 of 521 tokens — a 38% cut to the dominant overhead term. It changes `leaf_summary_schema()` and breaks the equality test that pins it against the OpenAI SDK's converter, so it is #5's surface rather than this issue's.
+2. **Whether `GenerationRequest` should gain an output cap** so the reservation is enforced rather than notional. Without it, a model may exceed its reserve and OpenAI will return `incomplete`, which the adapter currently reports without saying why.
+3. **The default direct cap.** Unset preserves the criterion as written, at the cost of the hierarchy being unreachable on defaults for every realistic input.
+4. **Whether the conservative counter should measure our own instructions and schema.** It charges 4.2–4.8× on ASCII that this project authors, which is what drives capacity negative at small windows. Calibrating it for controlled text would recover that, at the cost of the estimator no longer being uniformly safe.
+5. **Whether a runtime Ollama `show()` probe belongs behind an injectable seam**, giving local models a real window instead of an assumed one.
+6. **Whether to backfill `help=` on the ten pre-existing CLI flags.** None has one today, and the criterion asks for clear CLI help.

--- a/docs/plans/2026-09-03-strategy-selection-implementation.md
+++ b/docs/plans/2026-09-03-strategy-selection-implementation.md
@@ -1,0 +1,246 @@
+# Automatic Strategy Selection and Direct Summarization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Compute usable input capacity from real measurements, select `direct` or `hierarchical` safely, and complete the direct path by reusing the leaf machinery through a document-spanning segment.
+
+**Architecture:** A new `summarizer/budget.py` owns the context table, overhead measurement, capacity arithmetic, and selection. A new `summarizer/direct.py` owns the document-spanning segment and the direct stage. `StrategyConfig` joins `ParsedConfig` rather than `AppConfig`. The legacy CLI workflow is untouched.
+
+**Tech Stack:** Python 3, frozen dataclasses, `tiktoken`, the existing provider boundary, pytest
+
+**Test command:** `uv run --with-requirements requirements-dev.txt python -m pytest -q`
+
+Use exactly that form. `pytest` is absent from `requirements.txt`, so `uv run --with-requirements requirements.txt pytest` resolves the bare command off `PATH` to an interpreter with no project dependencies, and every third-party import then fails in a way that looks like broken source rather than a wrong interpreter.
+
+---
+
+### Task 1: Resolve a model's context window
+
+**Files:**
+- Create: `summarizer/budget.py`
+- Create: `tests/test_context_windows.py`
+
+**Step 1: Write failing resolution tests**
+
+Cover an exact table hit, a prefix hit (`gpt-4o-mini` must resolve the way `tiktoken`'s two-tier lookup makes it resolve), an explicit override winning over the table, an unknown OpenAI model, and an arbitrary Ollama tag. Assert the `assumed` flag distinguishes a table hit from a fallback:
+
+```python
+known = resolve_context_window(provider="openai", model="gpt-4o-mini")
+assert known.assumed is False
+unknown = resolve_context_window(provider="ollama", model="qwen3.8")
+assert unknown.assumed is True
+```
+
+**Step 2: Run the tests and verify they fail**
+
+Run: `uv run --with-requirements requirements-dev.txt python -m pytest tests/test_context_windows.py -q`
+
+Expected: FAIL because `summarizer.budget` does not exist.
+
+**Step 3: Implement the table and resolution**
+
+Add `ContextWindow` (tokens plus `assumed`), `_MODEL_CONTEXT_WINDOWS`, `_MODEL_PREFIX_CONTEXT_WINDOWS`, and `resolve_context_window(*, provider, model, explicit=None)`. Two-tier lookup, exact then longest matching prefix. Record in a comment that neither `openai` 3.7.0 nor `tiktoken` exposes a window, so the table is the only offline source and must be maintained by hand.
+
+**Step 4: Run focused and full tests**
+
+Run the focused file, then `uv run --with-requirements requirements-dev.txt python -m pytest -q`.
+
+Expected: 253 existing tests plus the new ones pass.
+
+**Step 5: Commit**
+
+```bash
+git add summarizer/budget.py tests/test_context_windows.py
+git commit -m "feat(budget): resolve model context windows"
+```
+
+### Task 2: Measure overhead and compute usable capacity
+
+**Files:**
+- Modify: `summarizer/budget.py`
+- Create: `tests/test_budget.py`
+
+**Step 1: Write failing measurement and arithmetic tests**
+
+Pin the measured overhead so that editing the instructions or the record fails loudly. Use a deterministic character counter for the arithmetic, and one real-encoding case guarded by the established skip pattern.
+
+Cover: overhead rising when overlap is configured; capacity equal to `window − overhead − reserve − margin`; the margin taking the larger of its fixed and fractional terms; and a non-positive capacity raising `BudgetError` whose message contains every term.
+
+```python
+with pytest.raises(BudgetError) as error:
+    usable_input_capacity(window=ContextWindow(4096, assumed=True), ...)
+for term in ("4096", "overhead", "reserve", "margin"):
+    assert term in str(error.value)
+```
+
+**Step 2: Run the tests and verify they fail**
+
+Expected: FAIL because `measure_overhead` and `usable_input_capacity` do not exist.
+
+**Step 3: Implement measurement and arithmetic**
+
+Add `OverheadMeasurement`, `measure_overhead(counter, *, with_overlap)`, `safety_margin(window, config)`, `usable_input_capacity(...)`, and `BudgetError`.
+
+Measure by counting the filled instruction template, the compactly-serialized schema, and the fencing — never a hard-coded constant, because an acceptance criterion covers overhead changes. Take the overlap-carrying variant when overlap is configured, since it is the larger.
+
+**Step 4: Run focused and full tests**
+
+**Step 5: Commit**
+
+```bash
+git add summarizer/budget.py tests/test_budget.py
+git commit -m "feat(budget): measure prompt overhead and usable capacity"
+```
+
+### Task 3: Configure strategy
+
+**Files:**
+- Modify: `summarizer/config.py`
+- Create: `tests/test_strategy_config.py`
+
+**Step 1: Write failing validation tests**
+
+Cover the default strategy, rejection of an unknown strategy name, rejection of a non-positive explicit window, a negative reserve, a fractional margin outside `[0, 1)`, and a non-positive direct cap. Assert `AppConfig` positional construction still works, since a commit exists in this repository's history solely to repair that.
+
+**Step 2: Run the tests and verify they fail**
+
+**Step 3: Implement `StrategyConfig`**
+
+Add `StrategyName = Literal["auto", "direct", "hierarchical"]` and a frozen `StrategyConfig` validating in `__post_init__`, mirroring how `AppConfig` validates `provider`.
+
+**Step 4: Run focused and full tests**
+
+**Step 5: Commit**
+
+```bash
+git add summarizer/config.py tests/test_strategy_config.py
+git commit -m "feat(config): add strategy and budget configuration"
+```
+
+### Task 4: Select a strategy and report why
+
+**Files:**
+- Modify: `summarizer/budget.py`
+- Create: `tests/test_strategy_selection.py`
+
+**Step 1: Write failing selection tests**
+
+Cover a document one token under capacity selecting `direct` and one token over selecting `hierarchical`; explicit `hierarchical` never measuring; explicit `direct` over capacity raising `BudgetError` with its arithmetic; an unknown window routing `auto` to hierarchical even when the document fits; the direct cap forcing hierarchical; and determinism of the report across runs.
+
+Assert the report carries the counter identity and exactness, every overhead term, and a machine-readable reason.
+
+**Step 2: Run the tests and verify they fail**
+
+**Step 3: Implement selection**
+
+Add `BudgetReport` and `select_strategy(document, counter, *, provider, model, config)`. Measure the document with `counter.count(document.text)` — the text a direct request actually sends, not a sum of segment counts.
+
+**Step 4: Run focused and full tests**
+
+**Step 5: Commit**
+
+```bash
+git add summarizer/budget.py tests/test_strategy_selection.py
+git commit -m "feat(budget): select a strategy from a measured budget"
+```
+
+### Task 5: Summarize a whole document directly
+
+**Files:**
+- Modify: `summarizer/segmentation.py`
+- Modify: `summarizer/leaf.py`
+- Create: `summarizer/direct.py`
+- Create: `tests/test_direct.py`
+- Modify: `tests/test_leaf_prompt.py`
+
+**Step 1: Write failing direct tests**
+
+Cover a document-spanning segment reconstructing the whole canonical text with `BoundaryKind.DOCUMENT`; the prompt not describing the input as a fragment; a successful direct summary returning one `SummaryNode` at level zero whose provenance is the single identifier; a quotation from anywhere in the document validating; a malformed response failing with the document's identifier; exactly one provider call; and determinism.
+
+**Step 2: Run the tests and verify they fail**
+
+**Step 3: Implement the direct path**
+
+Add `BoundaryKind.DOCUMENT`. A unit that is the entire document has no boundary *within* a document, and reporting `HARD` or `PARAGRAPH` would misstate provenance.
+
+In `summarizer/leaf.py`, select the prompt's framing sentence on whether the unit is the whole document, and bump `LEAF_PROMPT_VERSION`. Telling a model it is reading "one region of a longer document" when it is reading everything invites it to hedge about absent context, which is the opposite of the cohesive result required.
+
+In `summarizer/direct.py`, add `whole_document_segment(document, counter)` and `summarize_direct(document, provider, counter, *, model, timeout_seconds)`, reusing `build_leaf_request` and `parse_leaf_summary` unchanged.
+
+**Step 4: Run focused and full tests**
+
+**Step 5: Commit**
+
+```bash
+git add summarizer/segmentation.py summarizer/leaf.py summarizer/direct.py tests/test_direct.py tests/test_leaf_prompt.py
+git commit -m "feat(direct): summarize a whole document in one call"
+```
+
+### Task 6: Expose strategy on the command line
+
+**Files:**
+- Modify: `summarizer/cli.py`
+- Modify: `tests/test_cli.py`
+- Modify: `tests/test_documented_cli.py`
+
+**Step 1: Write failing CLI tests**
+
+Cover the default strategy on a bare invocation, each strategy accepted, an unknown strategy exiting 2, each budget flag reaching `StrategyConfig`, and a rejected value producing a usage error rather than a traceback.
+
+Validation must surface through the argument parser. `main()` catches only `OSError` and `ProviderError`, so a `ValueError` escaping into it would print a traceback — which an existing CLI test already asserts against for other paths.
+
+**Step 2: Run the tests and verify they fail**
+
+**Step 3: Add the flags**
+
+Add `--strategy`, `--context-window`, `--max-output-tokens`, `--safety-margin-tokens`, `--safety-margin-fraction`, and `--max-direct-tokens`, with `help=` text, and add `strategy` to `ParsedConfig`. Keep the existing `try/except ValueError → parser.error` pattern so a bad value exits 2.
+
+Do not rewire `main()` onto the new pipeline. Issue #12 owns the end-to-end demonstration, and #4 and #5 both deliberately left the command line on the legacy path.
+
+**Step 4: Run focused and full tests**
+
+**Step 5: Commit**
+
+```bash
+git add summarizer/cli.py tests/test_cli.py tests/test_documented_cli.py
+git commit -m "feat(cli): configure summarization strategy"
+```
+
+### Task 7: Document the boundary and validate
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/plans/2026-09-03-strategy-selection-design.md`
+
+**Step 1: Document the budget and the strategy**
+
+State how usable capacity is derived, that overhead is measured rather than assumed, that an unknown window routes to hierarchical rather than guessing, that the output reserve is accounted for but not enforced, and that the command line accepts strategy configuration without yet running the new pipeline.
+
+Record the local-truncation hazard explicitly: OpenAI rejects an oversized request, while Ollama silently truncates the prompt and returns plausible output, so budget arithmetic is the only defence on that path.
+
+Preserve every literal string asserted by `tests/test_documented_cli.py`.
+
+**Step 2: Run the byte-compile check**
+
+Run: `uv run --with-requirements requirements-dev.txt python -m compileall -q summarizer tests`
+
+**Step 3: Run the complete suite through both import modes**
+
+Run it plain, then with `--import-mode=importlib`.
+
+**Step 4: Verify repository hygiene**
+
+Run: `git status --short`
+
+Expected: only intended issue #6 changes; no cache, log, output, or credential files.
+
+**Step 5: Commit**
+
+```bash
+git add README.md docs/plans/2026-09-03-strategy-selection-design.md
+git commit -m "chore: document strategy selection and budgets"
+```
+
+**Step 6: Record acceptance evidence on issue #6**
+
+Map each criterion to its tests and implementation paths. Note that no live provider call is covered, and that the output reserve is notional until an output cap crosses the provider boundary. Do not close the issue until its PR merges.

--- a/summarizer/budget.py
+++ b/summarizer/budget.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Context windows have no offline source of truth, and for OpenAI no online one
+# either: the installed openai client exposes only {id, created, object,
+# owned_by, shutdown_date} per model, and tiktoken maps names to encodings
+# rather than to sizes. Ollama does report an architectural length through
+# show(), but the key is architecture-prefixed rather than tag-named (the tag
+# `qwen3.8` reports `qwen35.context_length`) and reaching it is a network call
+# that is unavailable before a pull. So this table is maintained by hand, and
+# anything missing from it is reported as assumed rather than as knowledge.
+_MODEL_CONTEXT_WINDOWS: dict[str, int] = {
+    "gpt-4": 8_192,
+    "gpt-4-32k": 32_768,
+    "gpt-3.5-turbo": 16_385,
+}
+
+# Matched by longest prefix, mirroring the two-tier lookup tiktoken already
+# uses and which is what makes a dated or suffixed model name resolve at all.
+_MODEL_PREFIX_CONTEXT_WINDOWS: dict[str, int] = {
+    "gpt-4o": 128_000,
+    "gpt-4o-mini": 128_000,
+    "gpt-4-turbo": 128_000,
+    "gpt-4.1": 1_047_576,
+    "gpt-5": 400_000,
+    "o1": 200_000,
+    "o3": 200_000,
+    "o4": 200_000,
+}
+
+# Deliberately small: an assumed window should not let an unknown model gamble
+# a large request. Selection routes an assumed window to hierarchical rather
+# than trusting it.
+ASSUMED_CONTEXT_WINDOW = 8_192
+
+
+@dataclass(frozen=True)
+class ContextWindow:
+    """A model's total context size, and whether that size is actually known."""
+
+    tokens: int
+    assumed: bool
+
+    def __post_init__(self) -> None:
+        if self.tokens <= 0:
+            raise ValueError("context window tokens must be positive")
+
+
+def resolve_context_window(
+    *,
+    provider: str,
+    model: str,
+    explicit: int | None = None,
+) -> ContextWindow:
+    """Resolve a model's context window without contacting a provider.
+
+    An explicit value is authoritative. Otherwise the table is consulted by
+    exact name and then by longest matching prefix. An unresolved model yields
+    an assumed window flagged as such, so a caller can decline to rely on it.
+    """
+    if explicit is not None:
+        if explicit <= 0:
+            raise ValueError("context window must be positive")
+        return ContextWindow(tokens=explicit, assumed=False)
+
+    if provider.strip().lower() == "openai":
+        name = model.strip()
+        exact = _MODEL_CONTEXT_WINDOWS.get(name)
+        if exact is not None:
+            return ContextWindow(tokens=exact, assumed=False)
+
+        matches = [
+            prefix
+            for prefix in _MODEL_PREFIX_CONTEXT_WINDOWS
+            if name.startswith(prefix)
+        ]
+        if matches:
+            longest = max(matches, key=len)
+            return ContextWindow(
+                tokens=_MODEL_PREFIX_CONTEXT_WINDOWS[longest], assumed=False
+            )
+
+    return ContextWindow(tokens=ASSUMED_CONTEXT_WINDOW, assumed=True)

--- a/summarizer/budget.py
+++ b/summarizer/budget.py
@@ -32,6 +32,9 @@ _MODEL_PREFIX_CONTEXT_WINDOWS: dict[str, int] = {
     "gpt-4.1": 1_047_576,
     "gpt-5": 400_000,
     "o1": 200_000,
+    # Nested under "o1" with a different window, which is what makes the
+    # longest-prefix rule observable rather than incidental.
+    "o1-mini": 128_000,
     "o3": 200_000,
     "o4": 200_000,
 }
@@ -124,6 +127,8 @@ def measure_overhead(
     a provider's tokenizer sees; an indented form would overstate it by about
     two thirds. Approximating downward is why a safety margin exists.
     """
+    # The probe uses a region framing, which is the longer of the two by three
+    # tokens, so the measurement covers a whole-document request as well.
     probe = _overhead_probe_segment(with_overlap=with_overlap)
     request = build_leaf_request(probe, model="probe", timeout_seconds=1)
 
@@ -258,6 +263,9 @@ def select_strategy(
     window = resolve_context_window(
         provider=provider, model=model, explicit=config.context_window
     )
+    # A direct request carries no overlap. A stage that sends overlap-carrying
+    # requests must measure its own overhead: the overlap variant is about 120
+    # tokens larger, and sizing against this figure would under-reserve.
     overhead = measure_overhead(counter, with_overlap=False)
     margin = safety_margin(window.tokens, config)
     capacity = usable_input_capacity(
@@ -270,6 +278,15 @@ def select_strategy(
         config.max_direct_tokens is not None
         and document_tokens > config.max_direct_tokens
     )
+
+    if config.strategy == "direct" and window.assumed:
+        raise BudgetError(
+            f"direct summarization was requested but the context window for "
+            f"model {model!r} is not known, so a fit cannot be established; "
+            f"pass an explicit context window to proceed. This matters most "
+            f"on a provider that truncates an oversized prompt silently "
+            f"rather than rejecting it."
+        )
 
     if config.strategy == "direct" and not fits:
         raise BudgetError(

--- a/summarizer/budget.py
+++ b/summarizer/budget.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 
-from summarizer.config import StrategyConfig
+from summarizer.config import StrategyConfig, StrategyName
+from summarizer.ingestion import SourceDocument
 from summarizer.leaf import build_leaf_request
 from summarizer.segmentation import BoundaryKind, SourceSegment
 from summarizer.tokenization import TokenCounter
@@ -216,3 +217,126 @@ def usable_input_capacity(
             f"{config.max_output_tokens}, and a safety margin of {margin}"
         )
     return capacity
+
+
+@dataclass(frozen=True)
+class BudgetReport:
+    """Everything a strategy decision saw, and why it decided.
+
+    Returned to callers as run metadata, and safe to hash for later cache keys
+    because identical inputs produce an identical report.
+    """
+
+    strategy: StrategyName
+    reason: str
+    context_window_tokens: int
+    context_window_assumed: bool
+    counter_identity: str
+    counter_exact: bool
+    overhead: OverheadMeasurement
+    reserved_output_tokens: int
+    safety_margin_tokens: int
+    usable_input_capacity: int
+    document_tokens: int
+    fits: bool
+
+
+def select_strategy(
+    document: SourceDocument,
+    counter: TokenCounter,
+    *,
+    provider: str,
+    model: str,
+    config: StrategyConfig,
+) -> BudgetReport:
+    """Choose an execution path from a measured budget.
+
+    The document is measured with `counter.count(document.text)` - exactly the
+    text a direct request sends - rather than by summing segment counts, which
+    differs under a byte-pair encoder and diverges further under overlap.
+    """
+    window = resolve_context_window(
+        provider=provider, model=model, explicit=config.context_window
+    )
+    overhead = measure_overhead(counter, with_overlap=False)
+    margin = safety_margin(window.tokens, config)
+    capacity = usable_input_capacity(
+        window=window, overhead=overhead, config=config
+    )
+    document_tokens = counter.count(document.text)
+    fits = document_tokens <= capacity
+
+    capped = (
+        config.max_direct_tokens is not None
+        and document_tokens > config.max_direct_tokens
+    )
+
+    if config.strategy == "direct" and not fits:
+        raise BudgetError(
+            f"direct summarization was requested but the document does not fit: "
+            f"{document_tokens} tokens against a usable input capacity of "
+            f"{capacity} (context window {window.tokens}, overhead "
+            f"{overhead.total}, reserved output {config.max_output_tokens}, "
+            f"safety margin {margin})"
+        )
+
+    strategy, reason = _decide(
+        config=config,
+        fits=fits,
+        capped=capped,
+        assumed=window.assumed,
+        document_tokens=document_tokens,
+        capacity=capacity,
+    )
+
+    return BudgetReport(
+        strategy=strategy,
+        reason=reason,
+        context_window_tokens=window.tokens,
+        context_window_assumed=window.assumed,
+        counter_identity=counter.identity,
+        counter_exact=counter.exact,
+        overhead=overhead,
+        reserved_output_tokens=config.max_output_tokens,
+        safety_margin_tokens=margin,
+        usable_input_capacity=capacity,
+        document_tokens=document_tokens,
+        fits=fits,
+    )
+
+
+def _decide(
+    *,
+    config: StrategyConfig,
+    fits: bool,
+    capped: bool,
+    assumed: bool,
+    document_tokens: int,
+    capacity: int,
+) -> tuple[StrategyName, str]:
+    if config.strategy == "direct":
+        return "direct", (
+            f"direct was requested and {document_tokens} tokens fit a capacity "
+            f"of {capacity}"
+        )
+    if config.strategy == "hierarchical":
+        return "hierarchical", "hierarchical was requested explicitly"
+
+    if not fits:
+        return "hierarchical", (
+            f"{document_tokens} tokens exceed a usable input capacity of "
+            f"{capacity}"
+        )
+    if assumed:
+        return "hierarchical", (
+            "the context window is assumed rather than known, so a direct "
+            "request cannot be shown to fit"
+        )
+    if capped:
+        return "hierarchical", (
+            f"{document_tokens} tokens exceed the configured direct cap of "
+            f"{config.max_direct_tokens}"
+        )
+    return "direct", (
+        f"{document_tokens} tokens fit a usable input capacity of {capacity}"
+    )

--- a/summarizer/budget.py
+++ b/summarizer/budget.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+
+from summarizer.config import StrategyConfig
+from summarizer.leaf import build_leaf_request
+from summarizer.segmentation import BoundaryKind, SourceSegment
+from summarizer.tokenization import TokenCounter
 
 # Context windows have no offline source of truth, and for OpenAI no online one
 # either: the installed openai client exposes only {id, created, object,
@@ -33,6 +39,10 @@ _MODEL_PREFIX_CONTEXT_WINDOWS: dict[str, int] = {
 # a large request. Selection routes an assumed window to hierarchical rather
 # than trusting it.
 ASSUMED_CONTEXT_WINDOW = 8_192
+
+
+class BudgetError(ValueError):
+    """A configuration leaves no room to send a request safely."""
 
 
 @dataclass(frozen=True)
@@ -82,3 +92,127 @@ def resolve_context_window(
             )
 
     return ContextWindow(tokens=ASSUMED_CONTEXT_WINDOW, assumed=True)
+
+
+@dataclass(frozen=True)
+class OverheadMeasurement:
+    """What a request costs before any source text is added."""
+
+    instructions: int
+    schema: int
+    fencing: int
+
+    @property
+    def total(self) -> int:
+        return self.instructions + self.schema + self.fencing
+
+
+def measure_overhead(
+    counter: TokenCounter,
+    *,
+    with_overlap: bool,
+) -> OverheadMeasurement:
+    """Measure per-request overhead rather than assuming a constant.
+
+    A hard-coded figure would be wrong the moment the prompt or the record
+    changes, and the schema dominates: it is roughly two thirds of the total,
+    because the record's own docstrings are rendered into it and shipped on
+    every call.
+
+    The schema is counted in its compact serialization. That approximates what
+    a provider's tokenizer sees; an indented form would overstate it by about
+    two thirds. Approximating downward is why a safety margin exists.
+    """
+    probe = _overhead_probe_segment(with_overlap=with_overlap)
+    request = build_leaf_request(probe, model="probe", timeout_seconds=1)
+
+    schema = counter.count(
+        json.dumps(request.response_schema, separators=(",", ":"), sort_keys=True)
+    )
+    fencing = counter.count(request.input_text) - counter.count(probe.text)
+    return OverheadMeasurement(
+        instructions=counter.count(request.instructions),
+        schema=schema,
+        fencing=max(fencing, 0),
+    )
+
+
+def _overhead_probe_segment(*, with_overlap: bool) -> SourceSegment:
+    """Build the smallest segment that exercises the real request builder.
+
+    Measuring the assembled request rather than its parts means the fences and
+    the overlap instruction block are counted exactly as they are sent.
+    """
+    text = "probe"
+    if not with_overlap:
+        return SourceSegment(
+            segment_id="S000001",
+            source_id="0" * 64,
+            order=0,
+            text=text,
+            core_start=0,
+            core_end=len(text),
+            context_start=0,
+            context_end=len(text),
+            core_token_count=1,
+            token_count=1,
+            leading_overlap_tokens=0,
+            trailing_overlap_tokens=0,
+            boundary_kind=BoundaryKind.PARAGRAPH,
+        )
+
+    padded = f"a{text}b"
+    return SourceSegment(
+        segment_id="S000001",
+        source_id="0" * 64,
+        order=0,
+        text=padded,
+        core_start=1,
+        core_end=1 + len(text),
+        context_start=0,
+        context_end=len(padded),
+        core_token_count=1,
+        token_count=1,
+        leading_overlap_tokens=1,
+        trailing_overlap_tokens=1,
+        boundary_kind=BoundaryKind.PARAGRAPH,
+    )
+
+
+def safety_margin(window_tokens: int, config: StrategyConfig) -> int:
+    """Reserve the larger of a fixed floor and a proportional share.
+
+    A fixed margin alone is negligible against a very large window; a
+    proportional one alone discards thousands of tokens there while
+    under-protecting a small window.
+    """
+    proportional = int(window_tokens * config.safety_margin_fraction)
+    return max(config.safety_margin_tokens, proportional)
+
+
+def usable_input_capacity(
+    *,
+    window: ContextWindow,
+    overhead: OverheadMeasurement,
+    config: StrategyConfig,
+) -> int:
+    """Return how many tokens of source text a request may carry.
+
+    Raises `BudgetError` rather than returning a non-positive number, because
+    that outcome is reachable on default local configuration: the conservative
+    byte estimator charges over four times a real tokenizer on this project's
+    own ASCII.
+    """
+    margin = safety_margin(window.tokens, config)
+    capacity = (
+        window.tokens - overhead.total - config.max_output_tokens - margin
+    )
+    if capacity <= 0:
+        raise BudgetError(
+            f"no usable input capacity: a context window of {window.tokens} tokens "
+            f"leaves {capacity} after overhead of {overhead.total} "
+            f"(instructions {overhead.instructions}, schema {overhead.schema}, "
+            f"fencing {overhead.fencing}), reserved output of "
+            f"{config.max_output_tokens}, and a safety margin of {margin}"
+        )
+    return capacity

--- a/summarizer/cli.py
+++ b/summarizer/cli.py
@@ -112,8 +112,8 @@ def _parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help=(
-            "refuse direct above this document size even when it fits, to "
-            "force hierarchical execution"
+            "with --strategy auto, refuse direct above this document size "
+            "even when it fits, to force hierarchical execution"
         ),
     )
     return parser

--- a/summarizer/cli.py
+++ b/summarizer/cli.py
@@ -7,7 +7,12 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
-from summarizer.config import AppConfig, LegacyWorkflowConfig, RetryPolicy
+from summarizer.config import (
+    AppConfig,
+    LegacyWorkflowConfig,
+    RetryPolicy,
+    StrategyConfig,
+)
 from summarizer.legacy_workflow import LegacyWorkflow, run_file_workflow
 from summarizer.providers.base import (
     GenerationRequest,
@@ -25,6 +30,7 @@ class ParsedConfig:
     app: AppConfig
     retry: RetryPolicy
     workflow: LegacyWorkflowConfig
+    strategy: StrategyConfig = StrategyConfig()
 
 
 class _UnavailableProvider:
@@ -62,6 +68,54 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--chunk-size", type=int, default=1000)
     parser.add_argument("--max-chunks", type=int, default=-1)
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--strategy",
+        choices=("auto", "direct", "hierarchical"),
+        default="auto",
+        help=(
+            "how to execute: auto picks direct when the document provably "
+            "fits, direct requires that it fits, hierarchical always splits"
+        ),
+    )
+    parser.add_argument(
+        "--context-window",
+        type=int,
+        default=None,
+        help=(
+            "the model's total context size in tokens; required to use direct "
+            "with a model this project has no table entry for"
+        ),
+    )
+    parser.add_argument(
+        "--max-output-tokens",
+        type=int,
+        default=1024,
+        help="tokens reserved for the response when sizing a request",
+    )
+    parser.add_argument(
+        "--safety-margin-tokens",
+        type=int,
+        default=256,
+        help="minimum tokens held back from the context window",
+    )
+    parser.add_argument(
+        "--safety-margin-fraction",
+        type=float,
+        default=0.02,
+        help=(
+            "fraction of the context window held back; the larger of this and "
+            "--safety-margin-tokens applies"
+        ),
+    )
+    parser.add_argument(
+        "--max-direct-tokens",
+        type=int,
+        default=None,
+        help=(
+            "refuse direct above this document size even when it fits, to "
+            "force hierarchical execution"
+        ),
+    )
     return parser
 
 
@@ -83,6 +137,14 @@ def parse_args(argv: list[str] | None = None) -> ParsedConfig:
                 chunk_size=args.chunk_size,
                 max_chunks=args.max_chunks,
                 dry_run=args.dry_run,
+            ),
+            strategy=StrategyConfig(
+                strategy=args.strategy,
+                context_window=args.context_window,
+                max_output_tokens=args.max_output_tokens,
+                safety_margin_tokens=args.safety_margin_tokens,
+                safety_margin_fraction=args.safety_margin_fraction,
+                max_direct_tokens=args.max_direct_tokens,
             ),
         )
     except ValueError as error:

--- a/summarizer/config.py
+++ b/summarizer/config.py
@@ -69,3 +69,46 @@ class LegacyWorkflowConfig:
             raise ValueError("chunk_size must be positive")
         if self.max_chunks == 0 or self.max_chunks < -1:
             raise ValueError("max_chunks must be -1 or a positive integer")
+
+
+StrategyName = Literal["auto", "direct", "hierarchical"]
+
+
+@dataclass(frozen=True)
+class StrategyConfig:
+    """How to choose an execution path, and what to reserve when sizing it.
+
+    Kept separate from `AppConfig` rather than added to it. `AppConfig` is
+    constructed positionally in existing tests, and a commit exists in this
+    repository's history solely to repair that after a field moved, so budget
+    settings live in their own record instead of re-opening that hazard.
+    """
+
+    strategy: StrategyName = "auto"
+    context_window: int | None = None
+    max_output_tokens: int = 1_024
+    safety_margin_tokens: int = 256
+    safety_margin_fraction: float = 0.02
+    # Unset means capacity alone decides. A cap exists because a window-only
+    # rule sends very large documents in one call, which is a quality question
+    # this project has not answered; setting it makes hierarchical reachable
+    # without a code change.
+    max_direct_tokens: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.strategy not in ("auto", "direct", "hierarchical"):
+            raise ValueError(
+                "strategy must be one of auto, direct, or hierarchical"
+            )
+        if self.context_window is not None and self.context_window <= 0:
+            raise ValueError("context_window must be positive when provided")
+        if self.max_output_tokens <= 0:
+            raise ValueError("max_output_tokens must be positive")
+        if self.safety_margin_tokens < 0:
+            raise ValueError("safety_margin_tokens must not be negative")
+        if not isfinite(self.safety_margin_fraction) or not (
+            0 <= self.safety_margin_fraction < 1
+        ):
+            raise ValueError("safety_margin_fraction must be at least 0 and below 1")
+        if self.max_direct_tokens is not None and self.max_direct_tokens <= 0:
+            raise ValueError("max_direct_tokens must be positive when provided")

--- a/summarizer/direct.py
+++ b/summarizer/direct.py
@@ -7,10 +7,13 @@ from summarizer.segmentation import BoundaryKind, SourceSegment
 from summarizer.summaries import SummaryNode
 from summarizer.tokenization import TokenCounter
 
-# The identifier a whole-document summary cites. It matches the first segment
-# identifier segmentation would assign, so a later stage reading provenance
-# does not need to know which path produced the record.
-DOCUMENT_SEGMENT_ID = "S000001"
+# Deliberately distinct from segmentation's identifiers, which are
+# f"S{order+1:06d}". Reusing "S000001" would collide with the first segment of
+# a hierarchical run while covering a different extent, and provenance is a
+# bare tuple of identifiers with no boundary kind attached - so the two
+# meanings would be unrecoverable downstream, exactly where later stages need
+# to trace a root back to source.
+DOCUMENT_SEGMENT_ID = "D000001"
 
 
 def whole_document_segment(

--- a/summarizer/direct.py
+++ b/summarizer/direct.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from summarizer.ingestion import SourceDocument
+from summarizer.leaf import build_leaf_request, parse_leaf_summary
+from summarizer.providers.base import ModelProvider
+from summarizer.segmentation import BoundaryKind, SourceSegment
+from summarizer.summaries import SummaryNode
+from summarizer.tokenization import TokenCounter
+
+# The identifier a whole-document summary cites. It matches the first segment
+# identifier segmentation would assign, so a later stage reading provenance
+# does not need to know which path produced the record.
+DOCUMENT_SEGMENT_ID = "S000001"
+
+
+def whole_document_segment(
+    document: SourceDocument,
+    counter: TokenCounter,
+) -> SourceSegment:
+    """Represent an entire document as one segment.
+
+    Segmentation cannot be reused to produce this. A heading forces a hard
+    break during packing, so a document with more than one heading yields
+    several segments no matter how large the budget - measured at three
+    segments for a three-heading document at double the required budget. The
+    record is therefore constructed directly.
+
+    Because its core spans the whole document, the provenance rules the leaf
+    validator already enforces do the right thing unchanged: the single legal
+    identifier is this one, and every quotation is checked against the whole
+    text rather than a region of it.
+    """
+    tokens = counter.count(document.text)
+    return SourceSegment(
+        segment_id=DOCUMENT_SEGMENT_ID,
+        source_id=document.source_id,
+        order=0,
+        text=document.text,
+        core_start=0,
+        core_end=len(document.text),
+        context_start=0,
+        context_end=len(document.text),
+        core_token_count=tokens,
+        token_count=tokens,
+        leading_overlap_tokens=0,
+        trailing_overlap_tokens=0,
+        boundary_kind=BoundaryKind.DOCUMENT,
+    )
+
+
+def summarize_direct(
+    document: SourceDocument,
+    provider: ModelProvider,
+    counter: TokenCounter,
+    *,
+    model: str,
+    timeout_seconds: float,
+) -> SummaryNode:
+    """Summarize a whole document in a single call.
+
+    Reuses the leaf request builder, parser, and provenance validator, so a
+    direct result is the same record the rest of the hierarchy consumes. The
+    caller is responsible for having established that the document fits; this
+    function does not re-check the budget.
+    """
+    segment = whole_document_segment(document, counter)
+    request = build_leaf_request(
+        segment, model=model, timeout_seconds=timeout_seconds
+    )
+    result = provider.generate(request)
+    return parse_leaf_summary(result.text, segment=segment)

--- a/summarizer/leaf.py
+++ b/summarizer/leaf.py
@@ -21,38 +21,38 @@ LEAF_PROMPT_VERSION = "leaf-prompt/2"
 
 LEAF_SCHEMA_NAME = "leaf_summary"
 
-_REGION_FRAMING = (
-    "You extract structured information from one region of a longer document."
-)
-
 # A direct run holds everything there is. Telling a model it is reading a
 # fragment invites it to hedge about context it supposedly lacks, which is the
 # opposite of the cohesive result a whole-document summary is meant to give.
-_DOCUMENT_FRAMING = (
-    "You extract structured information from an entire document."
-)
+# The noun is therefore substituted throughout the instructions rather than in
+# the opening sentence alone: changing the framing while the rules still say
+# "region" five more times would not deliver the property.
+_REGION_FRAMING = "one region of a longer document"
+_DOCUMENT_FRAMING = "an entire document"
+_REGION_NOUN = "region"
+_DOCUMENT_NOUN = "document"
 
 _BASE_INSTRUCTIONS = """\
-{framing}
+You extract structured information from {framing}.
 
 Return one JSON object conforming to the supplied schema, and nothing else. Do \
 not write commentary before or after it.
 
 Follow these rules:
 
-- Summarize only what the region states. Do not add outside knowledge and do \
+- Summarize only what the {noun} states. Do not add outside knowledge and do \
 not infer beyond it.
 - Record each substantive point as a content unit, together with the evidence \
 supporting it.
 - Cite evidence with the identifier {segment_id} and no other value. It is the \
 only identifier valid for this request.
-- Copy a quotation character for character from the region. Leave quotations \
+- Copy a quotation character for character from the {noun}. Leave quotations \
 empty rather than paraphrasing into them.
 - Record qualifications, and mark a content unit uncertain, wherever the \
-region hedges. Leave contradictions empty when the region states none.
+{noun} hedges. Leave contradictions empty when the {noun} states none.
 - Use a level of 0.
 
-The region is delimited by these markers:
+The {noun} is delimited by these markers:
 
   begin: {begin}
   end: {end}
@@ -130,13 +130,10 @@ def build_leaf_request(
     begin = _fence(segment, "BEGIN")
     end = _fence(segment, "END")
 
-    framing = (
-        _DOCUMENT_FRAMING
-        if segment.boundary_kind is BoundaryKind.DOCUMENT
-        else _REGION_FRAMING
-    )
+    whole_document = segment.boundary_kind is BoundaryKind.DOCUMENT
     instructions = _BASE_INSTRUCTIONS.format(
-        framing=framing,
+        framing=_DOCUMENT_FRAMING if whole_document else _REGION_FRAMING,
+        noun=_DOCUMENT_NOUN if whole_document else _REGION_NOUN,
         segment_id=segment.segment_id,
         begin=begin,
         end=end,

--- a/summarizer/leaf.py
+++ b/summarizer/leaf.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from pydantic import ValidationError
 
 from summarizer.providers.base import GenerationRequest, ModelProvider
-from summarizer.segmentation import SourceSegment
+from summarizer.segmentation import BoundaryKind, SourceSegment
 from summarizer.summaries import SummaryNode, leaf_summary_schema
 
 
@@ -17,12 +17,23 @@ class LeafSummaryError(ValueError):
 
 # Identifies the prompt wording for cache keys and audit artifacts. Bump it
 # whenever a change could alter a model's output for identical input.
-LEAF_PROMPT_VERSION = "leaf-prompt/1"
+LEAF_PROMPT_VERSION = "leaf-prompt/2"
 
 LEAF_SCHEMA_NAME = "leaf_summary"
 
+_REGION_FRAMING = (
+    "You extract structured information from one region of a longer document."
+)
+
+# A direct run holds everything there is. Telling a model it is reading a
+# fragment invites it to hedge about context it supposedly lacks, which is the
+# opposite of the cohesive result a whole-document summary is meant to give.
+_DOCUMENT_FRAMING = (
+    "You extract structured information from an entire document."
+)
+
 _BASE_INSTRUCTIONS = """\
-You extract structured information from one region of a longer document.
+{framing}
 
 Return one JSON object conforming to the supplied schema, and nothing else. Do \
 not write commentary before or after it.
@@ -119,7 +130,13 @@ def build_leaf_request(
     begin = _fence(segment, "BEGIN")
     end = _fence(segment, "END")
 
+    framing = (
+        _DOCUMENT_FRAMING
+        if segment.boundary_kind is BoundaryKind.DOCUMENT
+        else _REGION_FRAMING
+    )
     instructions = _BASE_INSTRUCTIONS.format(
+        framing=framing,
         segment_id=segment.segment_id,
         begin=begin,
         end=end,

--- a/summarizer/segmentation.py
+++ b/summarizer/segmentation.py
@@ -23,6 +23,10 @@ class BoundaryKind(str, Enum):
     LIST = "list"
     SENTENCE = "sentence"
     HARD = "hard"
+    # A unit that is the entire document has no boundary *within* a document.
+    # Segmentation never produces this kind; the direct path does, and it tells
+    # a later stage that provenance covers everything rather than a region.
+    DOCUMENT = "document"
 
 
 class SegmentationError(ValueError):

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -77,9 +77,14 @@ def test_overhead_with_a_real_encoding_matches_the_measured_scale() -> None:
         TiktokenCounter.for_model("gpt-4o-mini"), with_overlap=False
     )
 
-    # Measured at 801 tokens when this was written; the schema dominates.
-    assert 600 < overhead.total < 1_100
-    assert overhead.schema > overhead.instructions
+    # Pinned exactly rather than banded: a band this wide would not notice the
+    # prompt or the record changing, which is the thing worth noticing.
+    assert (overhead.instructions, overhead.schema, overhead.fencing) == (
+        251,
+        521,
+        26,
+    )
+    assert overhead.total == 798
 
 
 def test_safety_margin_takes_the_larger_term() -> None:
@@ -124,8 +129,48 @@ def test_non_positive_capacity_reports_every_term() -> None:
         )
 
     message = str(error.value)
-    for term in ("1024", "overhead", "output", "margin"):
-        assert term in message
+    # Each term's own value, not just its label: "1024" alone would match the
+    # window as well as the reserve.
+    assert f"overhead of {overhead.total}" in message
+    assert f"instructions {overhead.instructions}" in message
+    assert f"schema {overhead.schema}" in message
+    assert "reserved output of 1024" in message
+    # The fixed floor dominates at this window: max(256, 0.05 * 1024) == 256.
+    assert "safety margin of 256" in message
+
+
+def test_capacity_of_exactly_zero_is_refused() -> None:
+    """The boundary itself, not merely a deeply negative case."""
+    config = StrategyConfig(
+        max_output_tokens=1, safety_margin_tokens=0, safety_margin_fraction=0
+    )
+    overhead = measure_overhead(CharacterCounter(), with_overlap=False)
+
+    with pytest.raises(BudgetError, match="leaves 0"):
+        usable_input_capacity(
+            window=ContextWindow(tokens=overhead.total + 1, assumed=False),
+            overhead=overhead,
+            config=config,
+        )
+
+
+def test_fencing_excludes_the_probe_text_it_measured_with() -> None:
+    """The fencing term is defined by that subtraction, so pin it.
+
+    Without this, dropping the subtraction leaves every assertion satisfied
+    while the fencing figure silently absorbs the probe's own text.
+    """
+    counter = CharacterCounter()
+    overhead = measure_overhead(counter, with_overlap=False)
+
+    from summarizer.budget import _overhead_probe_segment
+    from summarizer.leaf import build_leaf_request
+
+    probe = _overhead_probe_segment(with_overlap=False)
+    request = build_leaf_request(probe, model="probe", timeout_seconds=1)
+
+    assert overhead.fencing == len(request.input_text) - len(probe.text)
+    assert "probe" not in str(overhead.fencing)
 
 
 def test_capacity_is_deterministic() -> None:

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,139 @@
+from dataclasses import dataclass
+
+import pytest
+
+from summarizer.budget import (
+    BudgetError,
+    ContextWindow,
+    measure_overhead,
+    safety_margin,
+    usable_input_capacity,
+)
+from summarizer.config import StrategyConfig
+
+
+@dataclass(frozen=True)
+class CharacterCounter:
+    identity: str = "test:characters"
+    exact: bool = True
+    monotonic: bool = True
+
+    def count(self, text: str) -> int:
+        return len(text)
+
+
+def test_overhead_counts_instructions_schema_and_fencing() -> None:
+    overhead = measure_overhead(CharacterCounter(), with_overlap=False)
+
+    assert overhead.instructions > 0
+    assert overhead.schema > 0
+    assert overhead.fencing > 0
+    assert overhead.total == (
+        overhead.instructions + overhead.schema + overhead.fencing
+    )
+
+
+def test_overlap_increases_overhead() -> None:
+    """Overhead is not one constant: overlap adds a second instruction block."""
+    plain = measure_overhead(CharacterCounter(), with_overlap=False)
+    overlapping = measure_overhead(CharacterCounter(), with_overlap=True)
+
+    assert overlapping.total > plain.total
+    assert overlapping.instructions > plain.instructions
+
+
+def test_overhead_is_measured_not_assumed() -> None:
+    """A hard-coded constant would silently rot when the prompt changes.
+
+    Counting with a character counter makes the measurement equal the actual
+    character length of what is sent, so this fails if the schema or the
+    instruction template stops being measured at all.
+    """
+    from summarizer.summaries import leaf_summary_schema
+    import json
+
+    overhead = measure_overhead(CharacterCounter(), with_overlap=False)
+    schema_chars = len(json.dumps(leaf_summary_schema(), separators=(",", ":")))
+
+    assert overhead.schema == schema_chars
+
+
+def test_overhead_with_a_real_encoding_matches_the_measured_scale() -> None:
+    """One case against a real tokenizer, since every other test uses a fake.
+
+    The skip covers vocabulary availability alone, so a broken counter still
+    fails loudly rather than skipping.
+    """
+    import tiktoken
+
+    from summarizer.tokenization import TiktokenCounter
+
+    try:
+        tiktoken.encoding_for_model("gpt-4o-mini")
+    except Exception as error:  # pragma: no cover - depends on the local cache
+        pytest.skip(f"tiktoken vocabulary is unavailable offline: {error}")
+
+    overhead = measure_overhead(
+        TiktokenCounter.for_model("gpt-4o-mini"), with_overlap=False
+    )
+
+    # Measured at 801 tokens when this was written; the schema dominates.
+    assert 600 < overhead.total < 1_100
+    assert overhead.schema > overhead.instructions
+
+
+def test_safety_margin_takes_the_larger_term() -> None:
+    config = StrategyConfig(safety_margin_tokens=256, safety_margin_fraction=0.02)
+
+    # Fixed term dominates a small window.
+    assert safety_margin(4_096, config) == 256
+    # Fractional term dominates a large one.
+    assert safety_margin(128_000, config) == 2_560
+
+
+def test_capacity_subtracts_every_term() -> None:
+    config = StrategyConfig(
+        max_output_tokens=1_000,
+        safety_margin_tokens=100,
+        safety_margin_fraction=0,
+    )
+    overhead = measure_overhead(CharacterCounter(), with_overlap=False)
+    window = ContextWindow(tokens=overhead.total + 5_000, assumed=False)
+
+    capacity = usable_input_capacity(
+        window=window, overhead=overhead, config=config
+    )
+
+    assert capacity == 5_000 - 1_000 - 100
+
+
+def test_non_positive_capacity_reports_every_term() -> None:
+    """Reachable on default local configuration, so it must be a named error.
+
+    The byte estimator charges over four times a real tokenizer on the
+    project's own ASCII, which drives a small window negative.
+    """
+    config = StrategyConfig(max_output_tokens=1_024, safety_margin_fraction=0.05)
+    overhead = measure_overhead(CharacterCounter(), with_overlap=False)
+
+    with pytest.raises(BudgetError) as error:
+        usable_input_capacity(
+            window=ContextWindow(tokens=1_024, assumed=True),
+            overhead=overhead,
+            config=config,
+        )
+
+    message = str(error.value)
+    for term in ("1024", "overhead", "output", "margin"):
+        assert term in message
+
+
+def test_capacity_is_deterministic() -> None:
+    config = StrategyConfig()
+    overhead = measure_overhead(CharacterCounter(), with_overlap=False)
+    window = ContextWindow(tokens=overhead.total + 10_000, assumed=False)
+
+    first = usable_input_capacity(window=window, overhead=overhead, config=config)
+    second = usable_input_capacity(window=window, overhead=overhead, config=config)
+
+    assert first == second

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import pytest
 
 from summarizer import cli
 from summarizer.cli import main, parse_args
-from summarizer.config import AppConfig
+from summarizer.config import AppConfig, StrategyConfig
 from summarizer.providers.base import (
     GenerationRequest,
     GenerationResult,
@@ -264,3 +264,66 @@ def test_main_reports_unavailable_selected_ollama_service(
     assert "Ollama connection failed" in stderr
     assert selected[0].provider == "ollama"
     assert not (tmp_path / "output.txt").exists()
+
+
+def test_strategy_defaults_to_auto() -> None:
+    assert parse_args([]).strategy == StrategyConfig()
+
+
+@pytest.mark.parametrize("strategy", ["auto", "direct", "hierarchical"])
+def test_each_strategy_is_accepted(strategy: str) -> None:
+    assert parse_args(["--strategy", strategy]).strategy.strategy == strategy
+
+
+def test_budget_flags_reach_the_strategy_config() -> None:
+    parsed = parse_args(
+        [
+            "--strategy",
+            "direct",
+            "--context-window",
+            "32768",
+            "--max-output-tokens",
+            "2048",
+            "--safety-margin-tokens",
+            "512",
+            "--safety-margin-fraction",
+            "0.05",
+            "--max-direct-tokens",
+            "5000",
+        ]
+    )
+
+    assert parsed.strategy == StrategyConfig(
+        strategy="direct",
+        context_window=32_768,
+        max_output_tokens=2_048,
+        safety_margin_tokens=512,
+        safety_margin_fraction=0.05,
+        max_direct_tokens=5_000,
+    )
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--strategy", "sideways"],
+        ["--context-window", "0"],
+        ["--max-output-tokens", "0"],
+        ["--safety-margin-tokens", "-1"],
+        ["--safety-margin-fraction", "1.5"],
+        ["--max-direct-tokens", "0"],
+    ],
+)
+def test_invalid_budget_values_are_usage_errors(
+    argv: list[str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Validation must surface through the parser, not as a traceback.
+
+    `main` catches only OSError and ProviderError, so a ValueError escaping
+    into it would print a traceback instead of an actionable message.
+    """
+    with pytest.raises(SystemExit) as exit_info:
+        parse_args(argv)
+
+    assert exit_info.value.code == 2
+    assert "Traceback" not in capsys.readouterr().err

--- a/tests/test_context_windows.py
+++ b/tests/test_context_windows.py
@@ -24,13 +24,17 @@ def test_resolves_a_known_model_family_by_prefix() -> None:
 
 
 def test_prefers_the_longest_matching_prefix() -> None:
-    """A more specific family must win over a shorter one that also matches."""
-    windows = {
-        resolve_context_window(provider="openai", model=name).tokens
-        for name in ("gpt-4-turbo", "gpt-4")
-    }
+    """A more specific family must win over a shorter one that also matches.
 
-    assert len(windows) == 2
+    `o1-mini` matches both `o1` and `o1-mini`, and the two carry different
+    windows - which is what makes the longest-prefix rule observable rather
+    than incidental.
+    """
+    broad = resolve_context_window(provider="openai", model="o1-preview")
+    specific = resolve_context_window(provider="openai", model="o1-mini-2024")
+
+    assert broad.tokens == 200_000
+    assert specific.tokens == 128_000
 
 
 def test_an_explicit_window_overrides_the_table() -> None:
@@ -71,7 +75,9 @@ def test_an_explicit_window_rescues_an_unknown_model() -> None:
 
 def test_rejects_a_non_positive_explicit_window() -> None:
     for value in (0, -1):
-        with pytest.raises(ValueError, match="positive"):
+        # Matched on the resolver's own wording, so it cannot be satisfied by
+        # ContextWindow's near-identical message from a layer further in.
+        with pytest.raises(ValueError, match="^context window must be positive$"):
             resolve_context_window(
                 provider="openai", model="gpt-4o-mini", explicit=value
             )

--- a/tests/test_context_windows.py
+++ b/tests/test_context_windows.py
@@ -1,0 +1,82 @@
+import pytest
+
+from summarizer.budget import (
+    ASSUMED_CONTEXT_WINDOW,
+    ContextWindow,
+    resolve_context_window,
+)
+
+
+def test_resolves_a_known_model_exactly() -> None:
+    window = resolve_context_window(provider="openai", model="gpt-4o-mini")
+
+    assert window.tokens > 0
+    assert window.assumed is False
+
+
+def test_resolves_a_known_model_family_by_prefix() -> None:
+    """`gpt-4o-mini` has no exact entry in tiktoken either; prefixes carry it."""
+    exact = resolve_context_window(provider="openai", model="gpt-4o")
+    variant = resolve_context_window(provider="openai", model="gpt-4o-2024-11-20")
+
+    assert variant.tokens == exact.tokens
+    assert variant.assumed is False
+
+
+def test_prefers_the_longest_matching_prefix() -> None:
+    """A more specific family must win over a shorter one that also matches."""
+    windows = {
+        resolve_context_window(provider="openai", model=name).tokens
+        for name in ("gpt-4-turbo", "gpt-4")
+    }
+
+    assert len(windows) == 2
+
+
+def test_an_explicit_window_overrides_the_table() -> None:
+    window = resolve_context_window(
+        provider="openai", model="gpt-4o-mini", explicit=4_096
+    )
+
+    assert window == ContextWindow(tokens=4_096, assumed=False)
+
+
+def test_an_unknown_openai_model_is_assumed() -> None:
+    window = resolve_context_window(provider="openai", model="gpt-nonexistent-9")
+
+    assert window.tokens == ASSUMED_CONTEXT_WINDOW
+    assert window.assumed is True
+
+
+def test_an_arbitrary_ollama_tag_is_assumed() -> None:
+    """Neither the installed clients nor tiktoken expose a window offline.
+
+    An arbitrary local tag therefore cannot be known, and the epic requires
+    such tags keep working, so it resolves to an assumed window rather than
+    failing.
+    """
+    window = resolve_context_window(provider="ollama", model="qwen3.8")
+
+    assert window.tokens == ASSUMED_CONTEXT_WINDOW
+    assert window.assumed is True
+
+
+def test_an_explicit_window_rescues_an_unknown_model() -> None:
+    window = resolve_context_window(
+        provider="ollama", model="qwen3.8", explicit=262_144
+    )
+
+    assert window == ContextWindow(tokens=262_144, assumed=False)
+
+
+def test_rejects_a_non_positive_explicit_window() -> None:
+    for value in (0, -1):
+        with pytest.raises(ValueError, match="positive"):
+            resolve_context_window(
+                provider="openai", model="gpt-4o-mini", explicit=value
+            )
+
+
+def test_context_window_rejects_a_non_positive_size() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        ContextWindow(tokens=0, assumed=True)

--- a/tests/test_direct.py
+++ b/tests/test_direct.py
@@ -1,0 +1,199 @@
+import json
+from dataclasses import dataclass
+
+import pytest
+
+from summarizer.direct import summarize_direct, whole_document_segment
+from summarizer.ingestion import ingest_text
+from summarizer.leaf import LeafSummaryError, build_leaf_request
+from summarizer.providers.base import (
+    GenerationRequest,
+    GenerationResult,
+    ProviderConnectionError,
+)
+from summarizer.segmentation import BoundaryKind
+
+DOCUMENT = (
+    "# Archive migration\n\n"
+    "The archive moved in March. The index was rebuilt afterwards.\n\n"
+    "Staffing was unchanged."
+)
+
+
+@dataclass(frozen=True)
+class CharacterCounter:
+    identity: str = "test:characters"
+    exact: bool = True
+    monotonic: bool = True
+
+    def count(self, text: str) -> int:
+        return len(text)
+
+
+def payload(**overrides: object) -> str:
+    body: dict[str, object] = {
+        "summary": "The archive moved and the index was rebuilt.",
+        "content_units": [],
+        "entities": [],
+        "qualifications": [],
+        "contradictions": [],
+        "quotations": [],
+        "provenance": ["S000001"],
+        "level": 0,
+    }
+    body.update(overrides)
+    return json.dumps(body)
+
+
+class RecordingProvider:
+    def __init__(self, text: str | None = None) -> None:
+        self.requests: list[GenerationRequest] = []
+        self.text = text if text is not None else payload()
+
+    def generate(self, request: GenerationRequest) -> GenerationResult:
+        self.requests.append(request)
+        return GenerationResult(text=self.text, provider="fake", model=request.model)
+
+
+def test_whole_document_segment_spans_the_canonical_text() -> None:
+    document = ingest_text(DOCUMENT)
+
+    segment = whole_document_segment(document, CharacterCounter())
+
+    assert segment.text == document.text
+    assert (segment.core_start, segment.core_end) == (0, len(document.text))
+    assert (segment.context_start, segment.context_end) == (0, len(document.text))
+    assert segment.leading_overlap_tokens == 0
+    assert segment.trailing_overlap_tokens == 0
+    assert segment.segment_id == "S000001"
+    assert segment.source_id == document.source_id
+
+
+def test_whole_document_segment_is_labelled_as_a_whole_document() -> None:
+    """No boundary kind describing a break *within* a document would be true.
+
+    Segmentation never produces this kind, so it also tells a later stage that
+    provenance covers everything rather than a region.
+    """
+    segment = whole_document_segment(ingest_text(DOCUMENT), CharacterCounter())
+
+    assert segment.boundary_kind is BoundaryKind.DOCUMENT
+
+
+def test_the_prompt_does_not_describe_a_whole_document_as_a_fragment() -> None:
+    """Telling a model it holds a fragment invites it to hedge about context.
+
+    That is the opposite of the cohesive result a direct run is meant to give.
+    """
+    document = ingest_text(DOCUMENT)
+    whole = build_leaf_request(
+        whole_document_segment(document, CharacterCounter()),
+        model="m",
+        timeout_seconds=30,
+    )
+
+    assert "one region of a longer document" not in whole.instructions
+    assert "entire document" in whole.instructions
+
+
+def test_a_leaf_request_still_describes_a_region() -> None:
+    from summarizer.segmentation import SegmentationConfig, segment_document
+
+    segments = segment_document(
+        ingest_text(DOCUMENT), CharacterCounter(), SegmentationConfig(max_tokens=40)
+    )
+    leaf = build_leaf_request(segments[0], model="m", timeout_seconds=30)
+
+    assert "one region of a longer document" in leaf.instructions
+
+
+def test_summarizes_a_whole_document_in_one_call() -> None:
+    document = ingest_text(DOCUMENT)
+    provider = RecordingProvider()
+
+    node = summarize_direct(
+        document, provider, CharacterCounter(), model="m", timeout_seconds=30
+    )
+
+    assert node.level == 0
+    assert node.provenance == ("S000001",)
+    assert len(provider.requests) == 1
+    assert document.text in provider.requests[0].input_text
+
+
+def test_a_quotation_from_anywhere_in_the_document_validates() -> None:
+    """The whole document is attributable, unlike a segment's overlap context."""
+    document = ingest_text(DOCUMENT)
+    provider = RecordingProvider(
+        payload(
+            quotations=[
+                {"segment_id": "S000001", "quote": "Staffing was unchanged."}
+            ]
+        )
+    )
+
+    node = summarize_direct(
+        document, provider, CharacterCounter(), model="m", timeout_seconds=30
+    )
+
+    assert node.quotations[0].quote == "Staffing was unchanged."
+
+
+def test_rejects_a_fabricated_quotation() -> None:
+    provider = RecordingProvider(
+        payload(
+            quotations=[{"segment_id": "S000001", "quote": "the archive burned"}]
+        )
+    )
+
+    with pytest.raises(LeafSummaryError, match="quotation"):
+        summarize_direct(
+            ingest_text(DOCUMENT),
+            provider,
+            CharacterCounter(),
+            model="m",
+            timeout_seconds=30,
+        )
+
+
+def test_malformed_output_fails_naming_the_document_identifier() -> None:
+    provider = RecordingProvider("I would rather not.")
+
+    with pytest.raises(LeafSummaryError, match="S000001"):
+        summarize_direct(
+            ingest_text(DOCUMENT),
+            provider,
+            CharacterCounter(),
+            model="m",
+            timeout_seconds=30,
+        )
+
+
+def test_provider_failures_propagate_unchanged() -> None:
+    class FailingProvider:
+        def generate(self, request: GenerationRequest) -> GenerationResult:
+            raise ProviderConnectionError("service is unreachable")
+
+    with pytest.raises(ProviderConnectionError):
+        summarize_direct(
+            ingest_text(DOCUMENT),
+            FailingProvider(),
+            CharacterCounter(),
+            model="m",
+            timeout_seconds=30,
+        )
+
+
+def test_direct_requests_are_deterministic() -> None:
+    document = ingest_text(DOCUMENT)
+    first, second = RecordingProvider(), RecordingProvider()
+
+    node_one = summarize_direct(
+        document, first, CharacterCounter(), model="m", timeout_seconds=30
+    )
+    node_two = summarize_direct(
+        document, second, CharacterCounter(), model="m", timeout_seconds=30
+    )
+
+    assert node_one == node_two
+    assert first.requests == second.requests

--- a/tests/test_direct.py
+++ b/tests/test_direct.py
@@ -3,7 +3,11 @@ from dataclasses import dataclass
 
 import pytest
 
-from summarizer.direct import summarize_direct, whole_document_segment
+from summarizer.direct import (
+    DOCUMENT_SEGMENT_ID,
+    summarize_direct,
+    whole_document_segment,
+)
 from summarizer.ingestion import ingest_text
 from summarizer.leaf import LeafSummaryError, build_leaf_request
 from summarizer.providers.base import (
@@ -38,7 +42,7 @@ def payload(**overrides: object) -> str:
         "qualifications": [],
         "contradictions": [],
         "quotations": [],
-        "provenance": ["S000001"],
+        "provenance": [DOCUMENT_SEGMENT_ID],
         "level": 0,
     }
     body.update(overrides)
@@ -65,7 +69,7 @@ def test_whole_document_segment_spans_the_canonical_text() -> None:
     assert (segment.context_start, segment.context_end) == (0, len(document.text))
     assert segment.leading_overlap_tokens == 0
     assert segment.trailing_overlap_tokens == 0
-    assert segment.segment_id == "S000001"
+    assert segment.segment_id == DOCUMENT_SEGMENT_ID
     assert segment.source_id == document.source_id
 
 
@@ -92,8 +96,10 @@ def test_the_prompt_does_not_describe_a_whole_document_as_a_fragment() -> None:
         timeout_seconds=30,
     )
 
-    assert "one region of a longer document" not in whole.instructions
-    assert "entire document" in whole.instructions
+    # Assert the property, not just the sentence that was edited: the rules
+    # below the framing must not keep calling the input a region either.
+    assert "region" not in whole.instructions
+    assert "an entire document" in whole.instructions
 
 
 def test_a_leaf_request_still_describes_a_region() -> None:
@@ -105,6 +111,7 @@ def test_a_leaf_request_still_describes_a_region() -> None:
     leaf = build_leaf_request(segments[0], model="m", timeout_seconds=30)
 
     assert "one region of a longer document" in leaf.instructions
+    assert "the region states" in leaf.instructions
 
 
 def test_summarizes_a_whole_document_in_one_call() -> None:
@@ -116,7 +123,7 @@ def test_summarizes_a_whole_document_in_one_call() -> None:
     )
 
     assert node.level == 0
-    assert node.provenance == ("S000001",)
+    assert node.provenance == (DOCUMENT_SEGMENT_ID,)
     assert len(provider.requests) == 1
     assert document.text in provider.requests[0].input_text
 
@@ -127,7 +134,7 @@ def test_a_quotation_from_anywhere_in_the_document_validates() -> None:
     provider = RecordingProvider(
         payload(
             quotations=[
-                {"segment_id": "S000001", "quote": "Staffing was unchanged."}
+                {"segment_id": DOCUMENT_SEGMENT_ID, "quote": "Staffing was unchanged."}
             ]
         )
     )
@@ -142,7 +149,7 @@ def test_a_quotation_from_anywhere_in_the_document_validates() -> None:
 def test_rejects_a_fabricated_quotation() -> None:
     provider = RecordingProvider(
         payload(
-            quotations=[{"segment_id": "S000001", "quote": "the archive burned"}]
+            quotations=[{"segment_id": DOCUMENT_SEGMENT_ID, "quote": "the archive burned"}]
         )
     )
 
@@ -159,7 +166,7 @@ def test_rejects_a_fabricated_quotation() -> None:
 def test_malformed_output_fails_naming_the_document_identifier() -> None:
     provider = RecordingProvider("I would rather not.")
 
-    with pytest.raises(LeafSummaryError, match="S000001"):
+    with pytest.raises(LeafSummaryError, match=DOCUMENT_SEGMENT_ID):
         summarize_direct(
             ingest_text(DOCUMENT),
             provider,
@@ -197,3 +204,32 @@ def test_direct_requests_are_deterministic() -> None:
 
     assert node_one == node_two
     assert first.requests == second.requests
+
+
+def test_document_segment_records_its_measured_token_counts() -> None:
+    document = ingest_text(DOCUMENT)
+
+    segment = whole_document_segment(document, CharacterCounter())
+
+    assert segment.core_token_count == len(document.text)
+    assert segment.token_count == len(document.text)
+
+
+def test_explicit_direct_refuses_an_assumed_context_window() -> None:
+    """A guessed window cannot establish a fit.
+
+    This is the dangerous combination rather than a pedantic one: the local
+    provider truncates an oversized prompt silently instead of rejecting it,
+    so a fit checked against a guess yields a confidently ungrounded summary.
+    """
+    from summarizer.budget import BudgetError, select_strategy
+    from summarizer.config import StrategyConfig
+
+    with pytest.raises(BudgetError, match="not known"):
+        select_strategy(
+            ingest_text(DOCUMENT),
+            CharacterCounter(),
+            provider="ollama",
+            model="qwen3.8",
+            config=StrategyConfig(strategy="direct", context_window=None),
+        )

--- a/tests/test_documented_cli.py
+++ b/tests/test_documented_cli.py
@@ -27,6 +27,12 @@ def test_help_lists_every_documented_flag() -> None:
         "--chunk-size",
         "--max-chunks",
         "--dry-run",
+        "--strategy",
+        "--context-window",
+        "--max-output-tokens",
+        "--safety-margin-tokens",
+        "--safety-margin-fraction",
+        "--max-direct-tokens",
     ):
         assert flag in result.stdout
 

--- a/tests/test_strategy_config.py
+++ b/tests/test_strategy_config.py
@@ -1,0 +1,28 @@
+import pytest
+
+from summarizer.config import AppConfig, StrategyConfig
+
+
+def test_defaults_to_auto() -> None:
+    assert StrategyConfig().strategy == "auto"
+
+
+def test_rejects_an_unknown_strategy_at_the_record() -> None:
+    """Argparse `choices` catches the CLI path, so the record needs its own test.
+
+    A library caller passing a mis-cased or invented name would otherwise fall
+    through to the auto path silently.
+    """
+    for name in ("sideways", "Direct", "DIRECT", ""):
+        with pytest.raises(ValueError, match="strategy must be one of"):
+            StrategyConfig(strategy=name)  # type: ignore[arg-type]
+
+
+def test_app_config_still_accepts_positional_construction() -> None:
+    """A commit exists in this history solely to repair this after a field moved."""
+    from pathlib import Path
+
+    config = AppConfig(Path("in.txt"), Path("out.txt"), "model", 45)
+
+    assert config.model == "model"
+    assert config.timeout_seconds == 45

--- a/tests/test_strategy_selection.py
+++ b/tests/test_strategy_selection.py
@@ -1,0 +1,159 @@
+from dataclasses import dataclass
+
+import pytest
+
+from summarizer.budget import BudgetError, measure_overhead, select_strategy
+from summarizer.config import StrategyConfig
+from summarizer.ingestion import ingest_text
+
+
+@dataclass(frozen=True)
+class CharacterCounter:
+    identity: str = "test:characters"
+    exact: bool = True
+    monotonic: bool = True
+
+    def count(self, text: str) -> int:
+        return len(text)
+
+
+def config_for(document_tokens: int, *, slack: int, **overrides: object) -> StrategyConfig:
+    """Build a configuration whose capacity is `document_tokens + slack`."""
+    counter = CharacterCounter()
+    overhead = measure_overhead(counter, with_overlap=False)
+    base: dict[str, object] = {
+        "max_output_tokens": 1,
+        "safety_margin_tokens": 0,
+        "safety_margin_fraction": 0,
+    }
+    base.update(overrides)
+    window = overhead.total + 1 + document_tokens + slack
+    base["context_window"] = window
+    return StrategyConfig(**base)  # type: ignore[arg-type]
+
+
+def select(text: str, config: StrategyConfig):
+    return select_strategy(
+        ingest_text(text),
+        CharacterCounter(),
+        provider="openai",
+        model="gpt-4o-mini",
+        config=config,
+    )
+
+
+def test_selects_direct_when_the_document_fits() -> None:
+    text = "a" * 100
+    report = select(text, config_for(100, slack=1))
+
+    assert report.strategy == "direct"
+    assert report.document_tokens == 100
+    assert report.fits is True
+
+
+def test_selects_hierarchical_one_token_over_capacity() -> None:
+    """The boundary is exact, so both sides of it are pinned."""
+    text = "a" * 100
+    report = select(text, config_for(100, slack=-1))
+
+    assert report.strategy == "hierarchical"
+    assert report.fits is False
+
+
+def test_selects_direct_exactly_at_capacity() -> None:
+    text = "a" * 100
+    report = select(text, config_for(100, slack=0))
+
+    assert report.strategy == "direct"
+    assert report.document_tokens == report.usable_input_capacity
+
+
+def test_an_assumed_window_routes_auto_to_hierarchical() -> None:
+    """A guessed window must not be gambled on a direct request."""
+    report = select_strategy(
+        ingest_text("short"),
+        CharacterCounter(),
+        provider="ollama",
+        model="qwen3.8",
+        config=StrategyConfig(
+            max_output_tokens=1, safety_margin_tokens=0, safety_margin_fraction=0
+        ),
+    )
+
+    assert report.context_window_assumed is True
+    assert report.strategy == "hierarchical"
+    assert "assumed" in report.reason
+
+
+def test_a_direct_cap_forces_hierarchical_even_when_it_fits() -> None:
+    text = "a" * 100
+    report = select(text, config_for(100, slack=10_000, max_direct_tokens=50))
+
+    assert report.fits is True
+    assert report.strategy == "hierarchical"
+    assert "cap" in report.reason
+
+
+def test_explicit_hierarchical_is_honoured_even_when_the_document_fits() -> None:
+    report = select(
+        "a" * 100, config_for(100, slack=10_000, strategy="hierarchical")
+    )
+
+    assert report.fits is True
+    assert report.strategy == "hierarchical"
+    assert "explicitly" in report.reason
+
+
+@pytest.mark.parametrize("strategy", ["auto", "direct", "hierarchical"])
+def test_a_window_with_no_usable_capacity_fails_for_every_strategy(
+    strategy: str,
+) -> None:
+    """No strategy can proceed without positive capacity.
+
+    Hierarchical execution sizes each of its own requests against the same
+    capacity, so a window this small is a dead configuration rather than a
+    reason to prefer one path over another.
+    """
+    with pytest.raises(BudgetError, match="no usable input capacity"):
+        select(
+            "a" * 100,
+            StrategyConfig(
+                strategy=strategy,  # type: ignore[arg-type]
+                context_window=10,
+                max_output_tokens=1,
+                safety_margin_tokens=0,
+                safety_margin_fraction=0,
+            ),
+        )
+
+
+def test_explicit_direct_over_capacity_fails_with_its_arithmetic() -> None:
+    """Rejection happens before any provider call and shows the numbers used."""
+    with pytest.raises(BudgetError) as error:
+        select(
+            "a" * 100,
+            config_for(100, slack=-1, strategy="direct"),
+        )
+
+    message = str(error.value)
+    assert "100" in message
+    for term in ("capacity", "direct"):
+        assert term in message
+
+
+def test_report_carries_the_counter_and_overhead_it_used() -> None:
+    report = select("a" * 10, config_for(10, slack=100))
+
+    assert report.counter_identity == "test:characters"
+    assert report.counter_exact is True
+    assert report.overhead.total > 0
+    assert report.reserved_output_tokens == 1
+    assert report.reason
+
+
+def test_reports_are_deterministic() -> None:
+    text = "a" * 100
+
+    assert select(text, config_for(100, slack=5)) == select(
+        text, config_for(100, slack=5)
+    )


### PR DESCRIPTION
Closes #6. Design in the first commit; seven commits following its plan.

Adds safe context-budget arithmetic and completes the `direct` and `auto` paths. A document that provably fits is summarized in one call; one that does not is routed toward hierarchical execution instead of being sent as an invalid request.

## Acceptance criteria

| Criterion | Where |
|---|---|
| `auto` / `direct` / `hierarchical` with validation and CLI help | `StrategyConfig`, six flags in `summarizer/cli.py` · `tests/test_strategy_config.py`, `tests/test_cli.py` |
| Capacity from window minus prompt, schema, output, margin | `usable_input_capacity`, `measure_overhead` · `tests/test_budget.py` |
| `auto` picks direct only when it safely fits | `select_strategy` · `tests/test_strategy_selection.py` |
| Explicit `direct` fails pre-call with the budget explained | `select_strategy` raising `BudgetError` · `test_explicit_direct_over_capacity_fails_with_its_arithmetic` |
| Direct produces a cohesive result retaining provenance | `summarizer/direct.py` · `tests/test_direct.py` |
| Decisions and inputs available as run metadata | `BudgetReport` · `test_report_carries_the_counter_and_overhead_it_used` |
| Offline coverage of boundaries, overhead changes, margins, success, rejection, auto-hierarchical | `tests/test_budget.py`, `tests/test_strategy_selection.py`, `tests/test_direct.py` |

## Measurements that drove the design

| counter | overlap | instructions | schema | fencing | total |
|---|---|---|---|---|---|
| `tiktoken:o200k_base` | no | 249 | 521 | 24 | **794** |
| `tiktoken:o200k_base` | yes | 343 | 521 | 54 | **918** |
| `estimate:utf8-bytes` | no | 1,216 | 2,196 | 64 | **3,476** |

Three consequences, none of which was obvious up front:

- **The schema is 65% of fixed overhead** (521 of 794), and ~197 of those tokens are pydantic docstrings and generated `title` keys shipped to the model on every call. Trimming them is a 38% cut to the dominant term, but it changes `leaf_summary_schema()` and breaks the test pinning it against the OpenAI SDK's converter — so it's #5's surface, and it's listed as an open decision rather than done here.
- **Overhead is not one constant.** Overlap adds ~124 tokens. Assuming the smaller figure would over-fill the context.
- **Underflow is reachable, not theoretical.** The conservative estimator's 3,476-token overhead exhausts a small window by itself, so non-positive capacity is a named error carrying every term rather than a meaningless number.

## A falsified approach, recorded rather than dropped

The first design reused segmentation with a large budget, expecting a fitting document to pack into one segment. **It doesn't work:** a heading forces a hard break during packing, so a three-heading document yields three segments even at double the required budget. Verified before building on it. Direct therefore constructs a document-spanning segment directly — which still reuses the request builder, the tolerant parser, and the provenance validator hardened in #18 unchanged, because a core spanning the whole document makes those rules do the right thing automatically.

That needed two honest additions rather than workarounds: `BoundaryKind.DOCUMENT` (every existing kind describes a break *within* a document, so reporting one would misstate provenance), and a prompt framing that doesn't call the whole document "one region of a longer document" — telling a model it holds a fragment invites hedging about absent context, the opposite of a cohesive result. `LEAF_PROMPT_VERSION` is bumped accordingly; nothing caches on it yet.

## Judgement calls worth your review

- **An unrecognized model routes `auto` to hierarchical** rather than failing or treating a default window as knowledge. There is no offline source of truth for context windows — and for OpenAI no online one either; the client exposes no window and `tiktoken` maps names to encodings, not sizes. This keeps arbitrary local tags working, as the epic requires, at the cost of never using direct locally without `--context-window`.
- **`--max-direct-tokens` defaults to unset.** Window-only selection matches the criterion as written, but it means a 128K window swallows this repo's entire 85K-token corpus in one call and #7's hierarchy is unreachable on defaults. Whether one enormous call is *better* than a hierarchy is a quality question I'm not entitled to answer, so the lever exists and is off.
- **The output reserve is accounted for but not enforced.** Enforcing it means adding an output cap to `GenerationRequest` and mapping it in both adapters, re-opening the #3 contract for a criterion that only requires the reservation be accounted for.

`main()` is deliberately not rewired onto the new pipeline; #4 and #5 both left the CLI on the legacy path and #12 owns the end-to-end demonstration.

## Verification

303 tests (50 new) pass in both import modes, `compileall` clean, no network. An adversarial review is running against this diff and I'll push any findings.

**Not covered:** any live provider call. Also worth knowing — the two providers fail differently, and one doesn't fail at all: OpenAI rejects an oversized request, while Ollama silently truncates the prompt and returns plausible output, so on the local path this arithmetic is the only thing preventing a confidently ungrounded summary.